### PR TITLE
Add HTTP prefix to runner console output

### DIFF
--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -19,7 +19,7 @@ internal struct WebsiteRunner {
         let portNumber = 8000
 
         print("""
-        🌍 Starting web server at localhost:\(portNumber)
+        🌍 Starting web server at http://localhost:\(portNumber)
 
         Press any key to stop the server and exit
         """)


### PR DESCRIPTION
Prefixes the console output of the hostname with `http://` so that one can cmd-click to open the page right from the terminal.