### PR TITLE
Fix path for nested items

### DIFF
--- a/Sources/Publish/Internal/MarkdownFileHandler.swift
+++ b/Sources/Publish/Internal/MarkdownFileHandler.swift
@@ -44,15 +44,18 @@ internal struct MarkdownFileHandler<Site: Website> {
                 }
 
                 do {
-                    var path = file.nameExcludingExtension
+                    let fileName = file.nameExcludingExtension
+                    let path: Path
 
                     if let parentPath = file.parent?.path(relativeTo: subfolder) {
-                        path = parentPath + path
+                        path = Path(parentPath).appendingComponent(fileName)
+                    } else {
+                        path = Path(fileName)
                     }
 
                     let item = try factory.makeItem(
                         fromFile: file,
-                        at: Path(path),
+                        at: path,
                         sectionID: sectionID
                     )
 

--- a/Tests/PublishTests/Tests/HTMLGenerationTests.swift
+++ b/Tests/PublishTests/Tests/HTMLGenerationTests.swift
@@ -79,6 +79,28 @@ final class HTMLGenerationTests: PublishTestCase {
         )
     }
 
+    func testGeneratingNestedItemHTML() throws {
+        htmlFactory.makeItemHTML = { item, _ in
+            HTML(.body(.text(item.title)))
+        }
+
+        try publishWebsite(
+            using: Theme(htmlFactory: htmlFactory),
+            content: [
+                "one/2019/12/a.md": """
+                    # A
+                    """,
+                "two/2020/01/b.md": """
+                    # B
+                    """
+            ],
+            expectedHTML: [
+                "one/2019/12/a/index.html": "A",
+                "two/2020/01/b/index.html": "B"
+            ]
+        )
+    }
+
     func testGeneratingPageHTML() throws {
         htmlFactory.makePageHTML = { page, _ in
             HTML(.body(.text(page.title)))
@@ -302,6 +324,7 @@ extension HTMLGenerationTests {
             ("testGeneratingIndexHTML", testGeneratingIndexHTML),
             ("testGeneratingSectionHTML", testGeneratingSectionHTML),
             ("testGeneratingItemHTML", testGeneratingItemHTML),
+            ("testGeneratingNestedItemHTML", testGeneratingNestedItemHTML),
             ("testGeneratingPageHTML", testGeneratingPageHTML),
             ("testGeneratingTagHTML", testGeneratingTagHTML),
             ("testCleaningUpOldHTMLFiles", testCleaningUpOldHTMLFiles),


### PR DESCRIPTION
When you create an item in a nested folder (e.g., `/Content/blog/2019/03/article1.md`) Publish generates the item HTML at `/Output/blog/2019/03article1/index.html` instead of `/Output/blog/2019/03/article1/index.html`. This pull request fixes that issue.