### PR TITLE
Allow excluding section's path as well while generating SiteMap

### DIFF
--- a/Sources/Publish/API/PublishingStep.swift
+++ b/Sources/Publish/API/PublishingStep.swift
@@ -351,6 +351,7 @@ public extension PublishingStep {
     /// Generate a site map for the website, which is an XML file used
     /// for search engine indexing.
     /// - parameter excludedPaths: Any paths to exclude from the site map.
+    ///   Adding a section's path to the list removes the entire section, including all its items.
     /// - parameter indentation: How the site map should be indented.
     static func generateSiteMap(excluding excludedPaths: Set<Path> = [],
                                 indentedBy indentation: Indentation.Kind? = nil) -> Self {

--- a/Sources/Publish/Internal/SiteMapGenerator.swift
+++ b/Sources/Publish/Internal/SiteMapGenerator.swift
@@ -31,7 +31,11 @@ private extension SiteMapGenerator {
     func makeSiteMap(for sections: [Section<Site>], pages: [Page], site: Site) -> SiteMap {
         SiteMap(
             .forEach(sections) { section in
-                .group(
+                guard !excludedPaths.contains(section.path) else {
+                    return .empty
+                }
+
+                return .group(
                     .url(
                         .loc(site.url(for: section)),
                         .changefreq(.daily),

--- a/Tests/PublishTests/Infrastructure/Item+Stubbable.swift
+++ b/Tests/PublishTests/Infrastructure/Item+Stubbable.swift
@@ -24,8 +24,12 @@ extension Item: Stubbable where Site == WebsiteStub.WithoutItemMetadata {
     }
 
     static func stub(withSectionID sectionID: WebsiteStub.SectionID) -> Self {
+        stub(withPath: Path(.unique()), sectionID: sectionID)
+    }
+
+    static func stub(withPath path: Path, sectionID: WebsiteStub.SectionID) -> Self {
         Item(
-            path: Path(.unique()),
+            path: path,
             sectionID: sectionID,
             metadata: Site.ItemMetadata(),
             tags: [],

--- a/Tests/PublishTests/Tests/SiteMapGenerationTests.swift
+++ b/Tests/PublishTests/Tests/SiteMapGenerationTests.swift
@@ -60,6 +60,7 @@ final class SiteMapGenerationTests: PublishTestCase {
 
         let unexpectedLocations = [
             "https://swiftbysundell.com/one/itemB",
+            "https://swiftbysundell.com/two",
             "https://swiftbysundell.com/two/itemC",
             "https://swiftbysundell.com/two/itemD",
             "https://swiftbysundell.com/pageB"

--- a/Tests/PublishTests/Tests/SiteMapGenerationTests.swift
+++ b/Tests/PublishTests/Tests/SiteMapGenerationTests.swift
@@ -38,10 +38,13 @@ final class SiteMapGenerationTests: PublishTestCase {
         let site = try publishWebsite(in: folder, using: [
             .addItem(.stub(withPath: "itemA")),
             .addItem(.stub(withPath: "itemB")),
+            .addItem(.stub(withPath: "itemC", sectionID: .two)),
+            .addItem(.stub(withPath: "itemD", sectionID: .two)),
             .addPage(.stub(withPath: "pageA")),
             .addPage(.stub(withPath: "pageB")),
             .generateSiteMap(excluding: [
                 "one/itemB",
+                "two",
                 "pageB"
             ])
         ])
@@ -57,6 +60,8 @@ final class SiteMapGenerationTests: PublishTestCase {
 
         let unexpectedLocations = [
             "https://swiftbysundell.com/one/itemB",
+            "https://swiftbysundell.com/two/itemC",
+            "https://swiftbysundell.com/two/itemD",
             "https://swiftbysundell.com/pageB"
         ]
 
@@ -69,6 +74,8 @@ final class SiteMapGenerationTests: PublishTestCase {
         }
 
         XCTAssertNotNil(site.sections[.one].item(at: "itemB"))
+        XCTAssertNotNil(site.sections[.two].item(at: "itemC"))
+        XCTAssertNotNil(site.sections[.two].item(at: "itemD"))
         XCTAssertNotNil(site.pages["pageB"])
     }
 }


### PR DESCRIPTION
Use case:
I want to have a whole section which I do not want to be included in the SiteMap.