### PR TITLE
Use @autoclosure on PublishingStep.if

### DIFF
--- a/Sources/Publish/API/PublishingStep.swift
+++ b/Sources/Publish/API/PublishingStep.swift
@@ -39,8 +39,8 @@ public extension PublishingStep {
     /// - parameter condition: The condition that determines whether the
     ///   step should be run or not.
     /// - parameter step: The step to run if the condition is `true`.
-    static func `if`(_ condition: Bool, _ step: Self) -> Self {
-        condition ? step : .empty
+    static func `if`(_ condition: Bool, _ step: @autoclosure () -> Self) -> Self {
+        condition ? step() : .empty
     }
 
     /// Conditionally run a step if an optional isn't `nil`.


### PR DESCRIPTION
Don't evaluate the `step` if the condition is `false`. I believe this is more inline with Swift's short-circuit conditional behavior.