### PR TITLE
Allow plugins to be added to default pipeline

### DIFF
--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -62,7 +62,7 @@ public extension Website {
     /// - parameter deploymentMethod: How to deploy the website.
     /// - parameter additionalSteps: Any additional steps to add to the publishing
     ///   pipeline. Will be executed right before the HTML generation process begins.
-    /// - parameter plugins: Plugins to be installed beforehand.
+    /// - parameter plugins: Plugins to be installed at the start of the publishing process.
     /// - parameter file: The file that this method is called from (auto-inserted).
     /// - parameter line: The line that this method is called from (auto-inserted).
     @discardableResult

--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -62,6 +62,7 @@ public extension Website {
     /// - parameter deploymentMethod: How to deploy the website.
     /// - parameter additionalSteps: Any additional steps to add to the publishing
     ///   pipeline. Will be executed right before the HTML generation process begins.
+    /// - parameter plugins: Plugins to be installed beforehand.
     /// - parameter file: The file that this method is called from (auto-inserted).
     /// - parameter line: The line that this method is called from (auto-inserted).
     @discardableResult
@@ -72,10 +73,12 @@ public extension Website {
                  rssFeedConfig: RSSFeedConfiguration? = .default,
                  deployedUsing deploymentMethod: DeploymentMethod<Self>? = nil,
                  additionalSteps: [PublishingStep<Self>] = [],
+                 plugins: [Plugin<Self>] = [],
                  file: StaticString = #file) throws -> PublishedWebsite<Self> {
         try publish(
             at: path,
             using: [
+                .group(plugins.map(PublishingStep.installPlugin)),
                 .optional(.copyResources()),
                 .addMarkdownFiles(),
                 .sortItems(by: \.date, order: .descending),

--- a/Tests/PublishTests/Infrastructure/PublishTestCase.swift
+++ b/Tests/PublishTests/Infrastructure/PublishTestCase.swift
@@ -30,6 +30,7 @@ class PublishTestCase: XCTestCase {
         using theme: Theme<WebsiteStub.WithoutItemMetadata>,
         content: [Path : String] = [:],
         additionalSteps: [PublishingStep<WebsiteStub.WithoutItemMetadata>] = [],
+        plugins: [Plugin<WebsiteStub.WithoutItemMetadata>] = [],
         expectedHTML: [Path : String],
         allowWhitelistedOutputFiles: Bool = true,
         file: StaticString = #file,
@@ -47,7 +48,8 @@ class PublishTestCase: XCTestCase {
             withTheme: theme,
             at: Path(folder.path),
             rssFeedSections: [],
-            additionalSteps: additionalSteps
+            additionalSteps: additionalSteps,
+            plugins: plugins
         )
 
         try verifyOutput(


### PR DESCRIPTION
When adding the Splash plugin to my deployment pipeline I noticed that the only thing I wanted to change to the default pipeline was installing the plugin. I tried installing it through the `additionalSteps` API but they are called too late so they don't come into play. 

I wasn't sure whether to change the implementation to call those steps prior to anything else so I added an additional `plugins` parameter. 

Also, I wasn't sure how to add proper unit tests for this because the default pipeline is currently not tested at all, but I'd be glad to look into this more.