### PR TITLE
Reuse RSS/Podcast feeds if possible

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/johnsundell/plot.git",
         "state": {
           "branch": null,
-          "revision": "2e5574972f83bc5cdea59662986e701b86137642",
-          "version": "0.3.0"
+          "revision": "00bd4d695b20dba3ec7a09997c5817e55feb8893",
+          "version": "0.4.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/johnsundell/ink.git", from: "0.2.0"),
-        .package(url: "https://github.com/johnsundell/plot.git", from: "0.3.0"),
+        .package(url: "https://github.com/johnsundell/plot.git", from: "0.4.0"),
         .package(url: "https://github.com/johnsundell/files.git", from: "4.0.0"),
         .package(url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
         .package(url: "https://github.com/johnsundell/shellout.git", from: "2.2.0"),

--- a/Sources/Publish/API/FeedConfiguration.swift
+++ b/Sources/Publish/API/FeedConfiguration.swift
@@ -1,0 +1,21 @@
+/**
+*  Publish
+*  Copyright (c) John Sundell 2020
+*  MIT license, see LICENSE file for details
+*/
+
+import Foundation
+import Plot
+
+/// Protocol that acts as a shared API for configuring various feed
+/// generation steps, such as `generateRSSFeed` and `generatePodcastFeed`.
+public protocol FeedConfiguration: Codable, Equatable {
+    /// The path that the feed should be generated at.
+    var targetPath: Path { get }
+    /// The feed's TTL (or "Time to live") time interval.
+    var ttlInterval: TimeInterval { get }
+    /// The maximum number of items that the feed should contain.
+    var maximumItemCount: Int { get }
+    /// How the feed should be indented.
+    var indentation: Indentation.Kind? { get }
+}

--- a/Sources/Publish/API/PodcastAuthor.swift
+++ b/Sources/Publish/API/PodcastAuthor.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Type used to describe the author of a podcast.
-public struct PodcastAuthor {
+public struct PodcastAuthor: Codable, Equatable {
     /// The author's full name.
     public var name: String
     /// The author's email address.

--- a/Sources/Publish/API/PodcastFeedConfiguration.swift
+++ b/Sources/Publish/API/PodcastFeedConfiguration.swift
@@ -10,7 +10,11 @@ import Plot
 /// Configuration type used to customize how a podcast feed is generated when
 /// using the `generatePodcastFeed` step. To use a default implementation,
 /// use `PodcastFeedConfiguration.default`.
-public final class PodcastFeedConfiguration<Site: Website>: RSSFeedConfiguration {
+public struct PodcastFeedConfiguration<Site: Website>: FeedConfiguration {
+    public var targetPath: Path
+    public var ttlInterval: TimeInterval
+    public var maximumItemCount: Int
+    public var indentation: Indentation.Kind?
     /// The type of the podcast. See `PodcastType`.
     public var type: PodcastType
     /// A URL that points to the podcast's main image.
@@ -64,6 +68,10 @@ public final class PodcastFeedConfiguration<Site: Website>: RSSFeedConfiguration
         newFeedURL: URL? = nil,
         indentation: Indentation.Kind? = nil
     ) {
+        self.targetPath = targetPath
+        self.ttlInterval = ttlInterval
+        self.maximumItemCount = maximumItemCount
+        self.indentation = indentation
         self.type = type
         self.imageURL = imageURL
         self.copyrightText = copyrightText
@@ -74,10 +82,5 @@ public final class PodcastFeedConfiguration<Site: Website>: RSSFeedConfiguration
         self.subcategory = subcategory
         self.isExplicit = isExplicit
         self.newFeedURL = newFeedURL
-
-        super.init(targetPath: targetPath,
-                   ttlInterval: ttlInterval,
-                   maximumItemCount: maximumItemCount,
-                   indentation: indentation)
     }
 }

--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -31,13 +31,19 @@ public struct PublishingContext<Site: Website> {
     public private(set) var pages = [Path : Page]()
     /// A set containing all tags that are currently being used website-wide.
     public var allTags: Set<Tag> { tagCache.tags ?? gatherAllTags() }
+    /// Any date when the website was last generated.
+    public private(set) var lastGenerationDate: Date?
 
     private let folders: Folder.Group
     private var tagCache = TagCache()
+    private var stepName: String
 
-    internal init(site: Site, folders: Folder.Group) {
+    internal init(site: Site,
+                  folders: Folder.Group,
+                  firstStepName: String) {
         self.site = site
         self.folders = folders
+        self.stepName = firstStepName
 
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
@@ -160,6 +166,18 @@ public extension PublishingContext {
         }
     }
 
+    /// Return either an existing or newly created cache file for the
+    /// current publishing step. Cache files are scoped to the step
+    /// that they're created within, and can't be shared among steps.
+    /// Cache files aren't deleted in between publishing processes.
+    /// - parameter name: The name of the cache file to return.
+    /// - throws: An error in case a new file couldn't be created.
+    func cacheFile(named name: String) throws -> File {
+        let folderName = stepName.normalized()
+        let folder = try folders.caches.createSubfolderIfNeeded(withName: folderName)
+        return try folder.createFileIfNeeded(withName: name.normalized())
+    }
+
     /// Return all items within this website, sorted by a given key path.
     /// - parameter sortingKeyPath: The key path to sort the items by.
     /// - parameter order: The order to use when sorting the items.
@@ -249,6 +267,14 @@ public extension PublishingContext {
 }
 
 internal extension PublishingContext {
+    mutating func generationWillBegin() {
+        try? updateLastGenerationDate()
+    }
+
+    mutating func prepareForStep(named name: String) {
+        stepName = name
+    }
+
     func makeMarkdownContentFactory() -> MarkdownContentFactory<Site> {
         MarkdownContentFactory(
             parser: markdownParser,
@@ -278,6 +304,20 @@ internal extension PublishingContext {
 private extension PublishingContext {
     final class TagCache {
         var tags: Set<Tag>?
+    }
+
+    mutating func updateLastGenerationDate() throws {
+        let fileName = "lastGenerationDate"
+        let newString = String(Int(ceil(Date().timeIntervalSince1970)))
+
+        if let file = try? folders.internal.file(named: fileName) {
+            let oldInterval = try TimeInterval(file.readAsInt())
+            lastGenerationDate = Date(timeIntervalSince1970: oldInterval)
+            try file.write(newString)
+        } else {
+            let file = try folders.internal.createFile(named: fileName)
+            try file.write(newString)
+        }
     }
 
     func gatherAllTags() -> Set<Tag> {

--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -308,11 +308,15 @@ private extension PublishingContext {
 
     mutating func updateLastGenerationDate() throws {
         let fileName = "lastGenerationDate"
-        let newString = String(Int(ceil(Date().timeIntervalSince1970)))
+        let newString = String(Date().timeIntervalSince1970)
 
         if let file = try? folders.internal.file(named: fileName) {
-            let oldInterval = try TimeInterval(file.readAsInt())
-            lastGenerationDate = Date(timeIntervalSince1970: oldInterval)
+            let oldInterval = try TimeInterval(file.readAsString())
+
+            lastGenerationDate = oldInterval.map {
+                Date(timeIntervalSince1970: $0)
+            }
+
             try file.write(newString)
         } else {
             let file = try folders.internal.createFile(named: fileName)

--- a/Sources/Publish/API/PublishingStep.swift
+++ b/Sources/Publish/API/PublishingStep.swift
@@ -331,9 +331,12 @@ public extension PublishingStep {
     /// - parameter includedSectionIDs: The IDs of the sections which items
     ///   to include when generating the feed.
     /// - parameter config: The configuration to use when generating the feed.
+    /// - parameter date: The date that should act as the build and publishing
+    ///   date for the generated feed (default: the current date).
     static func generateRSSFeed(
         including includedSectionIDs: Set<Site.SectionID>,
-        config: RSSFeedConfiguration = .default
+        config: RSSFeedConfiguration = .default,
+        date: Date = Date()
     ) -> Self {
         guard !includedSectionIDs.isEmpty else { return .empty }
 
@@ -341,7 +344,8 @@ public extension PublishingStep {
             let generator = RSSFeedGenerator(
                 includedSectionIDs: includedSectionIDs,
                 config: config,
-                context: context
+                context: context,
+                date: date
             )
 
             try generator.generate()
@@ -372,15 +376,19 @@ public extension PublishingStep where Site.ItemMetadata: PodcastCompatibleWebsit
     /// and `audio` metadata, or an error will be thrown.
     /// - parameter section: The section to generate a podcast feed for.
     /// - parameter config: The configuration to use when generating the feed.
+    /// - parameter date: The date that should act as the build and publishing
+    ///   date for the generated feed (default: the current date).
     static func generatePodcastFeed(
         for section: Site.SectionID,
-        config: PodcastFeedConfiguration<Site>
+        config: PodcastFeedConfiguration<Site>,
+        date: Date = Date()
     ) -> Self {
         step(named: "Generate podcast feed") { context in
             let generator = PodcastFeedGenerator(
                 sectionID: section,
                 config: config,
-                context: context
+                context: context,
+                date: date
             )
 
             try generator.generate()
@@ -406,7 +414,7 @@ public extension PublishingStep {
 // MARK: - Implementation details
 
 internal extension PublishingStep {
-    enum Kind {
+    enum Kind: String {
         case system
         case generation
         case deployment

--- a/Sources/Publish/API/RSSFeedConfiguration.swift
+++ b/Sources/Publish/API/RSSFeedConfiguration.swift
@@ -10,14 +10,10 @@ import Plot
 /// Configuration type used to customize how an RSS feed is generated
 /// when using the `generateRSSFeed` step. To use a default implementation,
 /// use `RSSFeedConfiguration.default`.
-public class RSSFeedConfiguration {
-    /// The path that the feed should be generated at.
+public struct RSSFeedConfiguration: FeedConfiguration {
     public var targetPath: Path
-    /// The feed's TTL (or "Time to live") time interval.
     public var ttlInterval: TimeInterval
-    /// The maximum number of items that the feed should contain.
     public var maximumItemCount: Int
-    /// How the feed should be indented.
     public var indentation: Indentation.Kind?
 
     /// Initialize a new configuration instance.

--- a/Sources/Publish/API/Tag.swift
+++ b/Sources/Publish/API/Tag.swift
@@ -20,16 +20,6 @@ public extension Tag {
     /// Return a normalized string representation of this tag, which can
     /// be used to form URLs or identifiers.
     func normalizedString() -> String {
-        String(string.lowercased().compactMap { character in
-            if character.isWhitespace {
-                return "-"
-            }
-
-            if character.isLetter || character.isNumber {
-                return character
-            }
-
-            return nil
-        })
+        string.normalized()
     }
 }

--- a/Sources/Publish/Internal/Folder+Group.swift
+++ b/Sources/Publish/Internal/Folder+Group.swift
@@ -11,5 +11,6 @@ internal extension Folder {
         let root: Folder
         let output: Folder
         let `internal`: Folder
+        let caches: Folder
     }
 }

--- a/Sources/Publish/Internal/PodcastFeedGenerator.swift
+++ b/Sources/Publish/Internal/PodcastFeedGenerator.swift
@@ -11,29 +11,50 @@ internal struct PodcastFeedGenerator<Site: Website> where Site.ItemMetadata: Pod
     let sectionID: Site.SectionID
     let config: PodcastFeedConfiguration<Site>
     let context: PublishingContext<Site>
+    let date: Date
 
     func generate() throws {
+        let outputFile = try context.createOutputFile(at: config.targetPath)
+        let cacheFile = try context.cacheFile(named: "feed")
+        let oldCache = try? cacheFile.read().decoded() as Cache
         let section = context.sections[sectionID]
         let items = section.items.sorted(by: { $0.date > $1.date })
 
+        if let date = context.lastGenerationDate, let cache = oldCache {
+            if cache.config == config {
+                let newlyModifiedItem = items.first { $0.lastModified > date }
+
+                guard newlyModifiedItem != nil else {
+                    return try outputFile.write(cache.feed)
+                }
+            }
+        }
+
         let feed = try makeFeed(containing: items, section: section)
-        let file = try context.createOutputFile(at: config.targetPath)
-        try file.write(feed.render(indentedBy: config.indentation))
+            .render(indentedBy: config.indentation)
+
+        let newCache = Cache(config: config, feed: feed)
+        try cacheFile.write(newCache.encoded())
+        try outputFile.write(feed)
     }
 }
 
 private extension PodcastFeedGenerator {
+    struct Cache: Codable {
+        let config: PodcastFeedConfiguration<Site>
+        let feed: String
+    }
+
     func makeFeed(containing items: [Item<Site>],
-                  section: Section<Site>,
-                  currentDate: Date = Date()) throws -> PodcastFeed {
+                  section: Section<Site>) throws -> PodcastFeed {
         try PodcastFeed(
             .unwrap(config.newFeedURL, Node.newFeedURL),
             .title(context.site.name),
             .description(config.description),
             .link(context.site.url(for: section)),
             .language(context.site.language),
-            .lastBuildDate(currentDate, timeZone: context.dateFormatter.timeZone),
-            .pubDate(currentDate, timeZone: context.dateFormatter.timeZone),
+            .lastBuildDate(date, timeZone: context.dateFormatter.timeZone),
+            .pubDate(date, timeZone: context.dateFormatter.timeZone),
             .ttl(Int(config.ttlInterval)),
             .atomLink(context.site.url(for: config.targetPath)),
             .copyright(config.copyrightText),

--- a/Sources/Publish/Internal/RSSFeedGenerator.swift
+++ b/Sources/Publish/Internal/RSSFeedGenerator.swift
@@ -6,13 +6,18 @@
 
 import Foundation
 import Plot
+import Files
 
 internal struct RSSFeedGenerator<Site: Website> {
     let includedSectionIDs: Set<Site.SectionID>
     let config: RSSFeedConfiguration
     let context: PublishingContext<Site>
+    let date: Date
 
     func generate() throws {
+        let outputFile = try context.createOutputFile(at: config.targetPath)
+        let cacheFile = try context.cacheFile(named: "feed")
+        let oldCache = try? cacheFile.read().decoded() as Cache
         var items = [Item<Site>]()
 
         for sectionID in includedSectionIDs {
@@ -21,21 +26,38 @@ internal struct RSSFeedGenerator<Site: Website> {
 
         items.sort { $0.date > $1.date }
 
-        let feed = makeFeed(containing: items)
-        let file = try context.createOutputFile(at: config.targetPath)
-        try file.write(feed.render(indentedBy: config.indentation))
+        if let date = context.lastGenerationDate, let cache = oldCache {
+            if cache.config == config {
+                let newlyModifiedItem = items.first { $0.lastModified > date }
+
+                guard newlyModifiedItem != nil else {
+                    return try outputFile.write(cache.feed)
+                }
+            }
+        }
+
+        let feed = makeFeed(containing: items).render(indentedBy: config.indentation)
+
+        let newCache = Cache(config: config, feed: feed)
+        try cacheFile.write(newCache.encoded())
+        try outputFile.write(feed)
     }
 }
 
 private extension RSSFeedGenerator {
-    func makeFeed(containing items: [Item<Site>], currentDate: Date = Date()) -> RSS {
+    struct Cache: Codable {
+        let config: RSSFeedConfiguration
+        let feed: String
+    }
+
+    func makeFeed(containing items: [Item<Site>]) -> RSS {
         RSS(
             .title(context.site.name),
             .description(context.site.description),
             .link(context.site.url),
             .language(context.site.language),
-            .lastBuildDate(currentDate, timeZone: context.dateFormatter.timeZone),
-            .pubDate(currentDate, timeZone: context.dateFormatter.timeZone),
+            .lastBuildDate(date, timeZone: context.dateFormatter.timeZone),
+            .pubDate(date, timeZone: context.dateFormatter.timeZone),
             .ttl(Int(config.ttlInterval)),
             .atomLink(context.site.url(for: config.targetPath)),
             .forEach(items.prefix(config.maximumItemCount)) { item in

--- a/Sources/Publish/Internal/String+Normalized.swift
+++ b/Sources/Publish/Internal/String+Normalized.swift
@@ -1,0 +1,21 @@
+/**
+*  Publish
+*  Copyright (c) John Sundell 2020
+*  MIT license, see LICENSE file for details
+*/
+
+internal extension String {
+    func normalized() -> String {
+        String(lowercased().compactMap { character in
+            if character.isWhitespace {
+                return "-"
+            }
+
+            if character.isLetter || character.isNumber {
+                return character
+            }
+
+            return nil
+        })
+    }
+}

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -26,6 +26,7 @@ final class DeploymentTests: PublishTestCase {
         var deployed = false
 
         try publishWebsite(using: [
+            .step(named: "Custom") { _ in },
             .deploy(using: DeploymentMethod(name: "Deploy") { _ in
                 deployed = true
             })
@@ -46,7 +47,8 @@ final class DeploymentTests: PublishTestCase {
             },
             .installPlugin(Plugin(name: "Skipped") { _ in
                 pluginInstalled = true
-            })
+            }),
+            .deploy(using: DeploymentMethod(name: "Deploy") { _ in })
         ])
 
         XCTAssertFalse(generationPerformed)

--- a/Tests/PublishTests/Tests/ErrorTests.swift
+++ b/Tests/PublishTests/Tests/ErrorTests.swift
@@ -148,6 +148,26 @@ final class ErrorTests: PublishTestCase {
             )
         )
     }
+
+    func testErrorForNoPublishingSteps() throws {
+        assertErrorThrown(
+            try publishWebsite(using: []),
+            PublishingError(
+                infoMessage: "WebsiteName has no generation steps."
+            )
+        )
+
+        CommandLine.arguments.append("--deploy")
+
+        assertErrorThrown(
+            try publishWebsite(using: []),
+            PublishingError(
+                infoMessage: "WebsiteName has no deployment steps."
+            )
+        )
+
+        CommandLine.arguments.removeLast()
+    }
 }
 
 extension ErrorTests {
@@ -160,7 +180,8 @@ extension ErrorTests {
             ("testErrorForMissingPage", testErrorForMissingPage),
             ("testErrorForThrowingDuringPageMutation", testErrorForThrowingDuringPageMutation),
             ("testErrorForMissingFolder", testErrorForMissingFolder),
-            ("testErrorForMissingFile", testErrorForMissingFile)
+            ("testErrorForMissingFile", testErrorForMissingFile),
+            ("testErrorForNoPublishingSteps", testErrorForNoPublishingSteps)
         ]
     }
 }

--- a/Tests/PublishTests/Tests/PodcastFeedGenerationTests.swift
+++ b/Tests/PublishTests/Tests/PodcastFeedGenerationTests.swift
@@ -12,16 +12,9 @@ final class PodcastFeedGenerationTests: PublishTestCase {
     func testOnlyIncludingSpecifiedSection() throws {
         let folder = try Folder.createTemporary()
 
-        try publishWebsiteWithPodcast(in: folder, using: [
-            .addMarkdownFiles(),
-            .generatePodcastFeed(for: .one, config: makeConfigStub())
-        ], content: [
+        try generateFeed(in: folder, content: [
             "one/a.md": """
-            ---
-            audio.url: https://audio.mp3
-            audio.duration: 05:02
-            audio.size: 12345
-            ---
+            \(makeStubbedAudioMetadata())
             # Included
             """,
             "two/b": "# Not included"
@@ -35,16 +28,9 @@ final class PodcastFeedGenerationTests: PublishTestCase {
     func testConvertingRelativeLinksToAbsolute() throws {
         let folder = try Folder.createTemporary()
 
-        try publishWebsiteWithPodcast(in: folder, using: [
-            .addMarkdownFiles(),
-            .generatePodcastFeed(for: .one, config: makeConfigStub())
-        ], content: [
+        try generateFeed(in: folder, content: [
             "one/item.md": """
-            ---
-            audio.url: https://audio.mp3
-            audio.duration: 05:02
-            audio.size: 12345
-            ---
+            \(makeStubbedAudioMetadata())
             BEGIN [Link](/page) ![Image](/image.png) [Link](https://apple.com) END
             """
         ])
@@ -58,20 +44,65 @@ final class PodcastFeedGenerationTests: PublishTestCase {
         <a href="https://apple.com">Link</a>
         """)
     }
+
+    func testReusingPreviousFeedIfNoItemsWereModified() throws {
+        let folder = try Folder.createTemporary()
+        let contentFile = try folder.createFile(at: "Content/one/item.md")
+        try contentFile.write(makeStubbedAudioMetadata())
+
+        try generateFeed(in: folder)
+        let feedA = try folder.file(at: "Output/feed.rss").readAsString()
+
+        let newDate = Date().addingTimeInterval(60 * 60)
+        try generateFeed(in: folder, date: newDate)
+        let feedB = try folder.file(at: "Output/feed.rss").readAsString()
+
+        XCTAssertEqual(feedA, feedB)
+
+        try FileManager.default.setAttributes([
+            .modificationDate: newDate
+        ], ofItemAtPath: contentFile.path)
+
+        try generateFeed(in: folder, date: newDate)
+        let feedC = try folder.file(at: "Output/feed.rss").readAsString()
+
+        XCTAssertNotEqual(feedB, feedC)
+    }
+
+    func testNotReusingPreviousFeedIfConfigChanged() throws {
+        let folder = try Folder.createTemporary()
+        let contentFile = try folder.createFile(at: "Content/one/item.md")
+        try contentFile.write(makeStubbedAudioMetadata())
+
+        try generateFeed(in: folder)
+        let feedA = try folder.file(at: "Output/feed.rss").readAsString()
+
+        var newConfig = try makeConfigStub()
+        newConfig.author.name = "New author name"
+        let newDate = Date().addingTimeInterval(60 * 60)
+        try generateFeed(in: folder, config: newConfig, date: newDate)
+        let feedB = try folder.file(at: "Output/feed.rss").readAsString()
+
+        XCTAssertNotEqual(feedA, feedB)
+    }
 }
 
 extension PodcastFeedGenerationTests {
     static var allTests: Linux.TestList<PodcastFeedGenerationTests> {
         [
             ("testOnlyIncludingSpecifiedSection", testOnlyIncludingSpecifiedSection),
-            ("testConvertingRelativeLinksToAbsolute", testConvertingRelativeLinksToAbsolute)
+            ("testConvertingRelativeLinksToAbsolute", testConvertingRelativeLinksToAbsolute),
+            ("testReusingPreviousFeedIfNoItemsWereModified", testReusingPreviousFeedIfNoItemsWereModified),
+            ("testNotReusingPreviousFeedIfConfigChanged", testNotReusingPreviousFeedIfConfigChanged)
         ]
     }
 }
 
 private extension PodcastFeedGenerationTests {
-    func makeConfigStub() throws -> PodcastFeedConfiguration<WebsiteStub.WithPodcastMetadata> {
-        try PodcastFeedConfiguration(
+    typealias Configuration = PodcastFeedConfiguration<WebsiteStub.WithPodcastMetadata>
+
+    func makeConfigStub() throws -> Configuration {
+        try Configuration(
             targetPath: .defaultForRSSFeed,
             imageURL: require(URL(string: "image.png")),
             copyrightText: "John Appleseed 2019",
@@ -83,5 +114,29 @@ private extension PodcastFeedGenerationTests {
             subtitle: "Subtitle",
             category: "Category"
         )
+    }
+
+    func makeStubbedAudioMetadata() -> String {
+        """
+        ---
+        audio.url: https://audio.mp3
+        audio.duration: 05:02
+        audio.size: 12345
+        ---
+        """
+    }
+
+    func generateFeed(in folder: Folder,
+                      config: Configuration? = nil,
+                      date: Date = Date(),
+                      content: [Path : String] = [:]) throws {
+        try publishWebsiteWithPodcast(in: folder, using: [
+            .addMarkdownFiles(),
+            .generatePodcastFeed(
+                for: .one,
+                config: config ?? makeConfigStub(),
+                date: date
+            )
+        ], content: content)
     }
 }

--- a/Tests/PublishTests/Tests/PodcastFeedGenerationTests.swift
+++ b/Tests/PublishTests/Tests/PodcastFeedGenerationTests.swift
@@ -59,10 +59,7 @@ final class PodcastFeedGenerationTests: PublishTestCase {
 
         XCTAssertEqual(feedA, feedB)
 
-        try FileManager.default.setAttributes([
-            .modificationDate: newDate
-        ], ofItemAtPath: contentFile.path)
-
+        try contentFile.append("New content")
         try generateFeed(in: folder, date: newDate)
         let feedC = try folder.file(at: "Output/feed.rss").readAsString()
 

--- a/Tests/PublishTests/Tests/RSSFeedGenerationTests.swift
+++ b/Tests/PublishTests/Tests/RSSFeedGenerationTests.swift
@@ -13,13 +13,7 @@ final class RSSFeedGenerationTests: PublishTestCase {
     func testOnlyIncludingSpecifiedSections() throws {
         let folder = try Folder.createTemporary()
 
-        try publishWebsite(in: folder, using: [
-            .addMarkdownFiles(),
-            .generateRSSFeed(
-                including: [.one],
-                config: RSSFeedConfiguration(targetPath: "feed.rss")
-            )
-        ], content: [
+        try generateFeed(in: folder, content: [
             "one/a.md": "Included",
             "two/b.md": "Not included"
         ])
@@ -32,14 +26,10 @@ final class RSSFeedGenerationTests: PublishTestCase {
     func testConvertingRelativeLinksToAbsolute() throws {
         let folder = try Folder.createTemporary()
 
-        try publishWebsite(in: folder, using: [
-            .addMarkdownFiles(),
-            .generateRSSFeed(
-                including: [.one],
-                config: RSSFeedConfiguration(targetPath: "feed.rss")
-            )
-        ], content: [
-            "one/item.md": "BEGIN [Link](/page) ![Image](/image.png) [Link](https://apple.com) END"
+        try generateFeed(in: folder, content: [
+            "one/item.md": """
+            BEGIN [Link](/page) ![Image](/image.png) [Link](https://apple.com) END
+            """
         ])
 
         let feed = try folder.file(at: "Output/feed.rss").readAsString()
@@ -51,13 +41,69 @@ final class RSSFeedGenerationTests: PublishTestCase {
         <a href="https://apple.com">Link</a>
         """)
     }
+
+    func testReusingPreviousFeedIfNoItemsWereModified() throws {
+        let folder = try Folder.createTemporary()
+        let contentFile = try folder.createFile(at: "Content/one/item.md")
+
+        try generateFeed(in: folder)
+        let feedA = try folder.file(at: "Output/feed.rss").readAsString()
+
+        let newDate = Date().addingTimeInterval(60 * 60)
+        try generateFeed(in: folder, date: newDate)
+        let feedB = try folder.file(at: "Output/feed.rss").readAsString()
+
+        XCTAssertEqual(feedA, feedB)
+
+        try FileManager.default.setAttributes([
+            .modificationDate: newDate
+        ], ofItemAtPath: contentFile.path)
+
+        try generateFeed(in: folder, date: newDate)
+        let feedC = try folder.file(at: "Output/feed.rss").readAsString()
+
+        XCTAssertNotEqual(feedB, feedC)
+    }
+
+    func testNotReusingPreviousFeedIfConfigChanged() throws {
+        let folder = try Folder.createTemporary()
+        try folder.createFile(at: "Content/one/item.md")
+
+        try generateFeed(in: folder)
+        let feedA = try folder.file(at: "Output/feed.rss").readAsString()
+
+        let newConfig = RSSFeedConfiguration(ttlInterval: 5000)
+        let newDate = Date().addingTimeInterval(60 * 60)
+        try generateFeed(in: folder, config: newConfig, date: newDate)
+        let feedB = try folder.file(at: "Output/feed.rss").readAsString()
+
+        XCTAssertNotEqual(feedA, feedB)
+    }
 }
 
 extension RSSFeedGenerationTests {
     static var allTests: Linux.TestList<RSSFeedGenerationTests> {
         [
             ("testOnlyIncludingSpecifiedSections", testOnlyIncludingSpecifiedSections),
-            ("testConvertingRelativeLinksToAbsolute", testConvertingRelativeLinksToAbsolute)
+            ("testConvertingRelativeLinksToAbsolute", testConvertingRelativeLinksToAbsolute),
+            ("testReusingPreviousFeedIfNoItemsWereModified", testReusingPreviousFeedIfNoItemsWereModified),
+            ("testNotReusingPreviousFeedIfConfigChanged", testNotReusingPreviousFeedIfConfigChanged)
         ]
+    }
+}
+
+private extension RSSFeedGenerationTests {
+    func generateFeed(in folder: Folder,
+                      config: RSSFeedConfiguration = .default,
+                      date: Date = Date(),
+                      content: [Path : String] = [:]) throws {
+        try publishWebsite(in: folder, using: [
+            .addMarkdownFiles(),
+            .generateRSSFeed(
+                including: [.one],
+                config: config,
+                date: date
+            )
+        ], content: content)
     }
 }

--- a/Tests/PublishTests/Tests/RSSFeedGenerationTests.swift
+++ b/Tests/PublishTests/Tests/RSSFeedGenerationTests.swift
@@ -55,10 +55,7 @@ final class RSSFeedGenerationTests: PublishTestCase {
 
         XCTAssertEqual(feedA, feedB)
 
-        try FileManager.default.setAttributes([
-            .modificationDate: newDate
-        ], ofItemAtPath: contentFile.path)
-
+        try contentFile.append("New content")
         try generateFeed(in: folder, date: newDate)
         let feedC = try folder.file(at: "Output/feed.rss").readAsString()
 


### PR DESCRIPTION
This change makes Publish reuse any previously generated RSS and podcast feeds in case no new items have been added, no existing ones have been modified, and the configuration for generating the given feed hasn’t changed.

This is made possible by series of other changes:

- `PodcastFeedConfiguration` is no longer a subclass of its RSS counterpart, instead, both are separate structs that share a new `FeedConfiguration` protocol - in order to be able to enforce some degree of consistency.
- Both feed configuration types have been made `Equatable` and `Codable` in order to persist and compare them to previous configs.
- `PublishingContext` now has a `lastGenerationDate` API, which is used to compare the last modified item against when the website was last generated.
- `PublishingContext` now also enables any step to create cache files, which is used by `RSSFeedGenerator` and `PodcastFeedGenerator` to store caches of their previous configs + feeds.
- An error is now thrown if there are no runnable publishing steps, in order to be able to associate each `PublishingContext` with a current step name.
- Publish’s internal string normalization code is now available to all strings, rather than just tags, and used when creating cache files.
- Plot has been bumped to version `0.4.0`.

The main motivation for this change is to not cause each new publishing process to mark all RSS and podcast feeds as changed, which makes it harder to track actual changes using version control.