### PR TITLE
catching and reporting errors encountered in 'publish run'

### DIFF
--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -25,10 +25,15 @@ internal struct WebsiteRunner {
         """)
 
         DispatchQueue.global().async {
-            _ = try? shellOut(
-                to: "python -m SimpleHTTPServer \(portNumber)",
-                at: outputFolder.path
-            )
+            do {
+                _ = try shellOut(
+                    to: "python -m SimpleHTTPServer \(portNumber)",
+                    at: outputFolder.path
+                )
+            } catch let error {
+                let message = (error as? ShellOutError)?.message ?? error.localizedDescription
+                print("Encountered error: \(message)")
+            }
         }
 
         _ = readLine()


### PR DESCRIPTION
Turns out I didn't have `SimpleHTTPServer` readily available and was experiencing some silent failures. Just grabbing the error and reporting it.

I often use [serve](https://www.npmjs.com/package/serve), aside from the initial javascript shock would having a cli parameter on `run` to specify the http server help anyone?