### PR TITLE
RSS/Podcast feeds: Invalidate cache when item count changed

### DIFF
--- a/Sources/Publish/Internal/PodcastFeedGenerator.swift
+++ b/Sources/Publish/Internal/PodcastFeedGenerator.swift
@@ -21,7 +21,7 @@ internal struct PodcastFeedGenerator<Site: Website> where Site.ItemMetadata: Pod
         let items = section.items.sorted(by: { $0.date > $1.date })
 
         if let date = context.lastGenerationDate, let cache = oldCache {
-            if cache.config == config {
+            if cache.config == config, cache.itemCount == items.count {
                 let newlyModifiedItem = items.first { $0.lastModified > date }
 
                 guard newlyModifiedItem != nil else {
@@ -33,7 +33,7 @@ internal struct PodcastFeedGenerator<Site: Website> where Site.ItemMetadata: Pod
         let feed = try makeFeed(containing: items, section: section)
             .render(indentedBy: config.indentation)
 
-        let newCache = Cache(config: config, feed: feed)
+        let newCache = Cache(config: config, feed: feed, itemCount: items.count)
         try cacheFile.write(newCache.encoded())
         try outputFile.write(feed)
     }
@@ -43,6 +43,7 @@ private extension PodcastFeedGenerator {
     struct Cache: Codable {
         let config: PodcastFeedConfiguration<Site>
         let feed: String
+        let itemCount: Int
     }
 
     func makeFeed(containing items: [Item<Site>],

--- a/Sources/Publish/Internal/RSSFeedGenerator.swift
+++ b/Sources/Publish/Internal/RSSFeedGenerator.swift
@@ -27,7 +27,7 @@ internal struct RSSFeedGenerator<Site: Website> {
         items.sort { $0.date > $1.date }
 
         if let date = context.lastGenerationDate, let cache = oldCache {
-            if cache.config == config {
+            if cache.config == config, cache.itemCount == items.count {
                 let newlyModifiedItem = items.first { $0.lastModified > date }
 
                 guard newlyModifiedItem != nil else {
@@ -38,7 +38,7 @@ internal struct RSSFeedGenerator<Site: Website> {
 
         let feed = makeFeed(containing: items).render(indentedBy: config.indentation)
 
-        let newCache = Cache(config: config, feed: feed)
+        let newCache = Cache(config: config, feed: feed, itemCount: items.count)
         try cacheFile.write(newCache.encoded())
         try outputFile.write(feed)
     }
@@ -48,6 +48,7 @@ private extension RSSFeedGenerator {
     struct Cache: Codable {
         let config: RSSFeedConfiguration
         let feed: String
+        let itemCount: Int
     }
 
     func makeFeed(containing items: [Item<Site>]) -> RSS {


### PR DESCRIPTION
When new items were added, even if those items don’t have a later modification date than the previous generated site, always re-generate all RSS and podcast feeds.