### PR TITLE
Enable dynamic port configuration for run CLI command

### DIFF
--- a/Sources/PublishCLICore/CLI.swift
+++ b/Sources/PublishCLICore/CLI.swift
@@ -1,11 +1,11 @@
 /**
-*  Publish
-*  Copyright (c) John Sundell 2019
-*  MIT license, see LICENSE file for details
-*/
+ *  Publish
+ *  Copyright (c) John Sundell 2019
+ *  MIT license, see LICENSE file for details
+ */
 
-import Foundation
 import Files
+import Foundation
 import ShellOut
 
 public struct CLI {
@@ -42,13 +42,9 @@ public struct CLI {
             let deployer = WebsiteDeployer(folder: folder)
             try deployer.deploy()
         case "run":
-            if arguments.count > 2, arguments[2].contains("-p=") || arguments[2].contains("--port="), let portNumber = extractPortNumber(from: arguments[2]) {
-                let runner = WebsiteRunner(folder: folder, portNumber: portNumber)
-                try runner.run()
-            } else {
-                let runner = WebsiteRunner(folder: folder)
-                try runner.run()
-            }
+            let portNumber = extractPortNumber(from: arguments)
+            let runner = WebsiteRunner(folder: folder, portNumber: portNumber)
+            try runner.run()
         default:
             outputHelpText()
         }
@@ -69,16 +65,25 @@ private extension CLI {
         - new: Set up a new website in the current folder.
         - generate: Generate the website in the current folder.
         - run: Generate and run a localhost server on default port 8000
-               for the website in the current folder. Use the
-               "-p=" or "--port=" option for customizing the default port.
+               for the website in the current folder. Use the "-p"
+               or "--port" option for customizing the default port.
         - deploy: Generate and deploy the website in the current
                folder, according to its deployment method.
         """)
     }
-    
-    private func extractPortNumber(from argument: String) -> Int? {
-        let equalSignIndex = argument.firstIndex(of: "=")!
-        let portNumberString = String(argument.suffix(from: argument.index(after: equalSignIndex)))
-        return Int(portNumberString)
+
+    private func extractPortNumber(from arguments: [String]) -> Int {
+        if arguments.count > 3 {
+            switch arguments[2] {
+            case "-p", "--port":
+                guard let portNumber = Int(arguments[3]) else {
+                    break
+                }
+                return portNumber
+            default:
+                return 8000
+            }
+        }
+        return 8000 // Default Port Number
     }
 }

--- a/Sources/PublishCLICore/CLI.swift
+++ b/Sources/PublishCLICore/CLI.swift
@@ -81,9 +81,9 @@ private extension CLI {
                 }
                 return portNumber
             default:
-                return 8000
+                return 8000 // default portNumber
             }
         }
-        return 8000 // Default Port Number
+        return 8000 // default portNumber
     }
 }

--- a/Sources/PublishCLICore/CLI.swift
+++ b/Sources/PublishCLICore/CLI.swift
@@ -42,8 +42,13 @@ public struct CLI {
             let deployer = WebsiteDeployer(folder: folder)
             try deployer.deploy()
         case "run":
-            let runner = WebsiteRunner(folder: folder)
-            try runner.run()
+            if arguments.count > 2, arguments[2].contains("-p=") || arguments[2].contains("--port="), let portNumber = extractPortNumber(from: arguments[2]) {
+                let runner = WebsiteRunner(folder: folder, portNumber: portNumber)
+                try runner.run()
+            } else {
+                let runner = WebsiteRunner(folder: folder)
+                try runner.run()
+            }
         default:
             outputHelpText()
         }
@@ -63,10 +68,17 @@ private extension CLI {
 
         - new: Set up a new website in the current folder.
         - generate: Generate the website in the current folder.
-        - run: Generate and run a localhost server on port 8000
-               for the website in the current folder.
+        - run: Generate and run a localhost server on default port 8000
+               for the website in the current folder. Use the
+               "-p=" or "--port=" option for customizing the default port.
         - deploy: Generate and deploy the website in the current
                folder, according to its deployment method.
         """)
+    }
+    
+    private func extractPortNumber(from argument: String) -> Int? {
+        let equalSignIndex = argument.firstIndex(of: "=")!
+        let portNumberString = String(argument.suffix(from: argument.index(after: equalSignIndex)))
+        return Int(portNumberString)
     }
 }

--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -10,7 +10,7 @@ import ShellOut
 
 internal struct WebsiteRunner {
     let folder: Folder
-    var portNumber = 8000
+    var portNumber: Int
 
     func run() throws {
         let generator = WebsiteGenerator(folder: folder)

--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -10,13 +10,13 @@ import ShellOut
 
 internal struct WebsiteRunner {
     let folder: Folder
+    var portNumber = 8000
 
     func run() throws {
         let generator = WebsiteGenerator(folder: folder)
         try generator.generate()
 
         let outputFolder = try resolveOutputFolder()
-        let portNumber = 8000
 
         print("""
         🌍 Starting web server at http://localhost:\(portNumber)
@@ -26,7 +26,7 @@ internal struct WebsiteRunner {
 
         DispatchQueue.global().async {
             _ = try? shellOut(
-                to: "python -m SimpleHTTPServer \(portNumber)",
+                to: "python -m SimpleHTTPServer \(self.portNumber)",
                 at: outputFolder.path
             )
         }

--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -27,7 +27,7 @@ internal struct WebsiteRunner {
         DispatchQueue.global().async {
             do {
                 _ = try shellOut(
-                    to: "python -m SimpleHTTPServer \(portNumber)",
+                    to: "python -m SimpleHTTPServer \(self.portNumber)",
                     at: outputFolder.path
                 )
             } catch let error {


### PR DESCRIPTION
On my mac the port 8000 was blocked, therefore I extended the run CLI command to support a dynamic config with the attributes "-p" and "--port".
Because the CLI seems to be lightweight I only introduced a command option for this specific usecase, but with enums etc. there could be the posibility of generally introducing options for existing CLI commands.