### PR TITLE
Proposal to support Slug for Cool URI support

### DIFF
--- a/FileOrganization.md
+++ b/FileOrganization.md
@@ -1,0 +1,11 @@
+## Cool URL management
+
+[Cool URIs don't change](https://www.w3.org/Provider/Style/URI) implies that the best practice is to keep a nice URI for your content.
+
+[Clean URL](https://en.wikipedia.org/wiki/Clean_URL#Slug) shows how a Slug feature can help with the cool URI.  
+
+The slug offers an alternative to using the markdown filename as the URI ending.  Many implementations use the Markdown frontmatter to specify the slug. (such as [Hugo Slug](https://gohugo.io/content-management/organization/#slug-1) )
+
+The current Publish implementation uses the filename as the Cool URI. It seems to be determined before the Markdown front-matter is parsed and decoded. The publishing path should be determined after parsing the front-matter.  I believe the inclusion in a Tag Index page occurs after such front-matter declares the tags.
+
+At the moment I am publishing this discussion paper, rather than submitting code as the code change looks significant.

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/johnsundell/files.git",
         "state": {
           "branch": null,
-          "revision": "941052daf1c0aa6999343ee899dd3d743c86f211",
-          "version": "4.1.0"
+          "revision": "6568bfe636f02dfd85dc9d51b3782555b83080d3",
+          "version": "4.0.2"
         }
       },
       {


### PR DESCRIPTION
The current Publish implementation uses the filename as the Cool URI. It seems to be determined before the Markdown front-matter is parsed and decoded. The publishing path should be determined after parsing the front-matter.  I believe the inclusion in a Tag Index page occurs after such front-matter declares the tags.

See the FileOrganization.md for some reference links.