### PR TITLE
Adding support for absolute path strings

### DIFF
--- a/Sources/Publish/API/Path.swift
+++ b/Sources/Publish/API/Path.swift
@@ -10,6 +10,7 @@ import Foundation
 /// location or to a resource, such as a file or image.
 public struct Path: StringWrapper {
     public var string: String
+    public var absolute: Bool
 
     public init(_ string: String, absolute: Bool = false) {
         self.string = string

--- a/Sources/Publish/API/Path.swift
+++ b/Sources/Publish/API/Path.swift
@@ -11,8 +11,9 @@ import Foundation
 public struct Path: StringWrapper {
     public var string: String
 
-    public init(_ string: String) {
+    public init(_ string: String, absolute: Bool = false) {
         self.string = string
+        self.absolute = absolute
     }
 }
 
@@ -27,7 +28,7 @@ public extension Path {
     /// Convert this path into an absolute string, which can be used to
     /// refer to locations and resources based on the root of a website.
     var absoluteString: String {
-        if string.first == "/" { return string }
+        if string.first == "/" || self.absolute { return string }
         return "/" + string
     }
 


### PR DESCRIPTION
Currently when calling the `head(for: , on: )` function and passing in a `stylesheetPaths` array, there is no way to pass in absolute paths. Which makes it impossible to import external stylesheets into the site without using the alternate `head` function and having to specify every single option for head. Which makes the `head(for: , on: )` function much less useful for the majority of use cases.

The goal of this PR is to fix that by adding an `absolute` boolean to the `Path` struct, and returning the string for absoluteString if that boolean is set to true.

This is really meant to be an initial PR. There are probably better ways to do this, but I don't quite have enough knowledge about the codebase to know what those are at this point. So feedback is welcome!