### PR TITLE
Closes down SimpleHTTPServer after spawn

### DIFF
--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -37,6 +37,14 @@ internal struct WebsiteRunner {
         }
 
         _ = readLine()
+        
+        print("""
+        🔌 Shutting down...
+        """)
+        _ = try shellOut(
+            to: "kill -9 `ps -ef | grep SimpleHTTPServer | grep \(self.portNumber) | awk '{print $2}'`",
+            at: outputFolder.path
+        )
     }
 }
 


### PR DESCRIPTION
The SimpleHTTPServer continues to run in the background normally meaning you can't have successive calls to ```publish run``` without an error occurring. This change kills the server task correctly after use.

ShellOut will throw an error, but the task is killed. Example run:

```
Press any key to stop the server and exit
 
🔌 Shutting down...
Encountered error: 
❌ ShellOut encountered an error
Status code: 9
Message: ""
Output: ""
```

I'm open to suggestions on how to do this another way, but wanted to get this out here in case others were facing the same issue as me when trying to iterate.

Reference for shell command: https://stackoverflow.com/questions/12647196/how-do-i-shut-down-a-python-simplehttpserver