### PR TITLE
CLI: Stop local web server when ‘publish run’ exits

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/johnsundell/shellout.git",
         "state": {
           "branch": null,
-          "revision": "4ebf25863deb9c3c02696704fc3d39736183f258",
-          "version": "2.2.1"
+          "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+          "version": "2.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/johnsundell/plot.git", from: "0.4.0"),
         .package(url: "https://github.com/johnsundell/files.git", from: "4.0.0"),
         .package(url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
-        .package(url: "https://github.com/johnsundell/shellout.git", from: "2.2.0"),
+        .package(url: "https://github.com/johnsundell/shellout.git", from: "2.3.0"),
         .package(url: "https://github.com/johnsundell/sweep.git", from: "0.3.0")
     ],
     targets: [

--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -41,7 +41,7 @@ internal struct WebsiteRunner {
             }
 
             serverProcess.terminate()
-            exit(0)
+            exit(1)
         }
 
         _ = readLine()


### PR DESCRIPTION
This patch fixes a CLI bug that would cause the local web server started by `publish run` to keep running indefinitely. Now, the server is properly shut down whenever the CLI exits.

Error handling has also been improved, and in case there’s already a `localhost` server running on the same port, a much richer error message with suggestions will now be displayed:

```
❌ Failed to start local web server:
A localhost server is already running on port number 8000.
- Perhaps another 'publish run' session is running?
- Publish uses Python's SimpleHTTPServer, so to find any
  running processes, you can use either Activity Monitor
  or the 'ps' command and search for 'python'. You can then
  terminate any previous process in order to start a new one.
```