### PR TITLE
Allow overriding of an item path in markdown metadata

### DIFF
--- a/Sources/Publish/Internal/MarkdownContentFactory.swift
+++ b/Sources/Publish/Internal/MarkdownContentFactory.swift
@@ -26,6 +26,7 @@ internal struct MarkdownContentFactory<Site: Website> {
         let decoder = makeMetadataDecoder(for: markdown)
 
         let metadata = try Site.ItemMetadata(from: decoder)
+        let path = try decoder.decodeIfPresent("path", as: Path.self) ?? path
         let tags = try decoder.decodeIfPresent("tags", as: [Tag].self)
         let content = try makeContent(fromMarkdown: markdown, file: file, decoder: decoder)
         let rssProperties = try decoder.decodeIfPresent("rss", as: ItemRSSProperties.self)

--- a/Tests/PublishTests/Tests/MarkdownTests.swift
+++ b/Tests/PublishTests/Tests/MarkdownTests.swift
@@ -26,6 +26,16 @@ final class MarkdownTests: PublishTestCase {
         XCTAssertEqual(item.title, "Overridden title")
     }
 
+    func testParsingFileWithOverriddenPath() throws {
+        let item = try generateItem(fromMarkdown: """
+        ---
+        path: overridden-path
+        ---
+        """)
+
+        XCTAssertEqual(item.path, "one/overridden-path")
+    }
+
     func testParsingFileWithBuiltInMetadata() throws {
         let item = try generateItem(fromMarkdown: """
         ---
@@ -135,6 +145,7 @@ extension MarkdownTests {
         [
             ("testParsingFileWithTitle", testParsingFileWithTitle),
             ("testParsingFileWithOverriddenTitle", testParsingFileWithOverriddenTitle),
+            ("testParsingFileWithOverriddenPath", testParsingFileWithOverriddenPath),
             ("testParsingFileWithBuiltInMetadata", testParsingFileWithBuiltInMetadata),
             ("testParsingFileWithCustomMetadata", testParsingFileWithCustomMetadata),
             ("testParsingPageInNestedFolder", testParsingPageInNestedFolder),


### PR DESCRIPTION
This was briefly discussed in #21 

This allows metadata contain an override value for the path, to be used instead of the resource filename.