### PR TITLE
Item resource filename

### DIFF
--- a/Sources/Publish/API/Item.swift
+++ b/Sources/Publish/API/Item.swift
@@ -19,7 +19,10 @@ public struct Item<Site: Website>: AnyItem, Hashable {
     /// this item is for.
     public var metadata: Site.ItemMetadata
     public var tags: [Tag]
+    /// The absolute path to this item relative to the root of the site
     public var path: Path { makeAbsolutePath() }
+    /// The name of the resource file used to generate this item
+    public let resourceFilename: String?
     public var content: Content
     public var rssProperties: ItemRSSProperties
 
@@ -35,11 +38,13 @@ public struct Item<Site: Website>: AnyItem, Hashable {
     /// - parameter rssProperties: Properties customizing the item's RSS representation.
     public init(path: Path,
                 sectionID: Site.SectionID,
+                resourceFilename: String? = nil,
                 metadata: Site.ItemMetadata,
                 tags: [Tag] = [],
                 content: Content = Content(),
                 rssProperties: ItemRSSProperties = .init()) {
         self.relativePath = path
+        self.resourceFilename = resourceFilename
         self.sectionID = sectionID
         self.metadata = metadata
         self.tags = tags

--- a/Sources/Publish/Internal/MarkdownContentFactory.swift
+++ b/Sources/Publish/Internal/MarkdownContentFactory.swift
@@ -26,6 +26,7 @@ internal struct MarkdownContentFactory<Site: Website> {
         let decoder = makeMetadataDecoder(for: markdown)
 
         let metadata = try Site.ItemMetadata(from: decoder)
+        let path = try decoder.decodeIfPresent("path", as: Path.self) ?? path
         let tags = try decoder.decodeIfPresent("tags", as: [Tag].self)
         let content = try makeContent(fromMarkdown: markdown, file: file, decoder: decoder)
         let rssProperties = try decoder.decodeIfPresent("rss", as: ItemRSSProperties.self)

--- a/Sources/Publish/Internal/MarkdownContentFactory.swift
+++ b/Sources/Publish/Internal/MarkdownContentFactory.swift
@@ -34,6 +34,7 @@ internal struct MarkdownContentFactory<Site: Website> {
         return Item(
             path: path,
             sectionID: sectionID,
+            resourceFilename: file.name,
             metadata: metadata,
             tags: tags ?? [],
             content: content,

--- a/Tests/PublishTests/Tests/MarkdownTests.swift
+++ b/Tests/PublishTests/Tests/MarkdownTests.swift
@@ -26,6 +26,16 @@ final class MarkdownTests: PublishTestCase {
         XCTAssertEqual(item.title, "Overridden title")
     }
 
+    func testParsingFileWithOverriddenPath() throws {
+        let item = try generateItem(fromMarkdown: """
+        ---
+        path: overridden-path
+        ---
+        """)
+
+        XCTAssertEqual(item.path, "one/overridden-path")
+    }
+
     func testParsingFileWithBuiltInMetadata() throws {
         let item = try generateItem(fromMarkdown: """
         ---
@@ -135,6 +145,7 @@ extension MarkdownTests {
         [
             ("testParsingFileWithTitle", testParsingFileWithTitle),
             ("testParsingFileWithOverriddenTitle", testParsingFileWithOverriddenTitle),
+            ("testParsingFileWithOverriddenPath", testParsingFileWithOverriddenPath),
             ("testParsingFileWithBuiltInMetadata", testParsingFileWithBuiltInMetadata),
             ("testParsingFileWithCustomMetadata", testParsingFileWithCustomMetadata),
             ("testParsingPageInNestedFolder", testParsingPageInNestedFolder),


### PR DESCRIPTION
This PR is reliant on the acceptance of #28 as it makes little sense without it.

Consider the following files making up the content for a section of a site:

- 01_installation
- 02_getting-started
- 03_advanced-techniqes

In this hypothetical site, it is important to present these items in order in the section. I have personally run into this when wanting to order sections containing a list of features and FAQs. I was solving this with an Item metadata field called **position**.

The issue with using the position metadata is that the filesystem will not sort based on this and it becomes a management headache if you want to be able to review site content in the correct order.

With the ability to access item.resourceFilename items can be sorted thus:

```swift
items.sorted(by: { $0.resourceFilename ?? "" < $1.resourceFilename ?? "" })
``` 

Then in the content of each file, the metadata for **path** can be set to the appropriate path for the file.

Neither this PR or #28 changes any fundamental way Publish operates and have no backward compatibility issues.