### PR TITLE
Update README with note on site regeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ try DeliciousRecipes().publish(using: [
 
 Even when added to a pipeline, deployment steps are disabled by default, and are only executed when the `--deploy` command line flag was passed (which can be added through Xcode’s `Product > Scheme > Edit Scheme...` menu), or by running the command line tool using `publish deploy`.
 
-Publish can also start a `localhost` web server for local testing and development, by using the `publish run` command.
+Publish can also start a `localhost` web server for local testing and development, by using the `publish run` command. To regenerate site content with the server running, use Product > Run on your site's package in Xcode.
 
 ## Quick start
 


### PR DESCRIPTION
Given the discussion on this in https://github.com/JohnSundell/Publish/pull/6, and my also discovering it the long way around, wanted to offer a quick tweak to the readme to clarify the local development and regeneration workflow. Might save some time for newcomers pending @JohnSundell's introduction of more automated solutions.

Thanks for a great project! 🙏🏽