### PR TITLE
Deploy now can throw git message from stderr

### DIFF
--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -78,7 +78,7 @@ public extension DeploymentMethod {
                     at: folder.path
                 )
             } catch let error as ShellOutError {
-                throw PublishingError(infoMessage: error.output)
+                throw PublishingError(infoMessage: error.message)
             } catch {
                 throw error
             }

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -78,6 +78,7 @@ final class DeploymentTests: PublishTestCase {
         let indexFile = try remote.file(named: "index.html")
         XCTAssertFalse(try indexFile.readAsString().isEmpty)
     }
+
 	func testGitDeploymentMethodWithError() throws {
         let container = try Folder.createTemporary()
         let remote = try container.createSubfolder(named: "Remote.git")

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -82,29 +82,29 @@ final class DeploymentTests: PublishTestCase {
         let container = try Folder.createTemporary()
         let remote = try container.createSubfolder(named: "Remote.git")
         let repo = try container.createSubfolder(named: "Repo")
-		
-		try shellOut(to: [
-			"git init",
-		], at: remote.path)
-		
-		// First generate
-		try publishWebsite(in: repo, using: [
-			.generateHTML(withTheme: .foundation)
-		])
-		
-		// Then deploy
-		CommandLine.arguments.append("--deploy")
-		
-		XCTAssertThrowsError(
-			try publishWebsite(in: repo,
-							   using: [
-								.deploy(using: .git(remote.path))
-			]),
-			"Expected an error to be thrown") {
-				(error) in
-				XCTAssert(error is PublishingError)
-		}
-	}
+
+        try shellOut(to: [
+            "git init",
+        ], at: remote.path)
+        
+        // First generate
+        try publishWebsite(in: repo, using: [
+            .generateHTML(withTheme: .foundation)
+        ])
+
+        // Then deploy
+        CommandLine.arguments.append("--deploy")
+
+        XCTAssertThrowsError(
+            try publishWebsite(in: repo,
+                               using: [
+                                .deploy(using: .git(remote.path))
+            ]),
+            "Expected an error to be thrown") {
+                (error) in
+                XCTAssert(error is PublishingError)
+        }
+    }
 }
 
 extension DeploymentTests {
@@ -112,7 +112,8 @@ extension DeploymentTests {
         [
             ("testDeploymentSkippedByDefault", testDeploymentSkippedByDefault),
             ("testGenerationStepsAndPluginsSkippedWhenDeploying", testGenerationStepsAndPluginsSkippedWhenDeploying),
-            ("testGitDeploymentMethod", testGitDeploymentMethod)
+            ("testGitDeploymentMethod", testGitDeploymentMethod),
+            ("testGitDeploymentMethodWithError",testGitDeploymentMethodWithError)
         ]
     }
 }

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -78,6 +78,33 @@ final class DeploymentTests: PublishTestCase {
         let indexFile = try remote.file(named: "index.html")
         XCTAssertFalse(try indexFile.readAsString().isEmpty)
     }
+	func testGitDeploymentMethodWithError() throws {
+        let container = try Folder.createTemporary()
+        let remote = try container.createSubfolder(named: "Remote.git")
+        let repo = try container.createSubfolder(named: "Repo")
+		
+		try shellOut(to: [
+			"git init",
+		], at: remote.path)
+		
+		// First generate
+		try publishWebsite(in: repo, using: [
+			.generateHTML(withTheme: .foundation)
+		])
+		
+		// Then deploy
+		CommandLine.arguments.append("--deploy")
+		
+		XCTAssertThrowsError(
+			try publishWebsite(in: repo,
+							   using: [
+								.deploy(using: .git(remote.path))
+			]),
+			"Expected an error to be thrown") {
+				(error) in
+				XCTAssert(error is PublishingError)
+		}
+	}
 }
 
 extension DeploymentTests {


### PR DESCRIPTION
Maybe because I was using multiple computers over Publish, I came across lots of deploying problems, sometimes I needed to `cd .publish/GitDeploy/.git` to know what's happening, this PR fix the error feeding.