### PR TITLE
Upgrade http server to Python 3

### DIFF
--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -30,7 +30,7 @@ internal struct WebsiteRunner {
         serverQueue.async {
             do {
                 _ = try shellOut(
-                    to: "python -m SimpleHTTPServer \(self.portNumber)",
+                    to: "python -m http.server \(self.portNumber)",
                     at: outputFolder.path,
                     process: serverProcess
                 )


### PR DESCRIPTION
Python 2 has been [sunset since Jan 1st, 2020](https://www.python.org/doc/sunset-python-2/) and [`SimpleHTTPServer` was merged into `http.server`  in Python 3](https://docs.python.org/2/library/simplehttpserver.html)