### PR TITLE
Path: Preserve external URLs when generating absolute strings

### DIFF
--- a/Sources/Publish/API/Path.swift
+++ b/Sources/Publish/API/Path.swift
@@ -27,7 +27,9 @@ public extension Path {
     /// Convert this path into an absolute string, which can be used to
     /// refer to locations and resources based on the root of a website.
     var absoluteString: String {
-        if string.first == "/" { return string }
+        guard string.first != "/" else { return string }
+        guard !string.hasPrefix("http://") else { return string }
+        guard !string.hasPrefix("https://") else { return string }
         return "/" + string
     }
 

--- a/Tests/PublishTests/Tests/PlotComponentTests.swift
+++ b/Tests/PublishTests/Tests/PlotComponentTests.swift
@@ -9,6 +9,32 @@ import Publish
 import Plot
 
 final class PlotComponentTests: PublishTestCase {
+    func testStylesheetPaths() {
+        let html = Node.head(
+            for: Page(path: "path", content: Content()),
+            on: WebsiteStub.WithoutItemMetadata(),
+            stylesheetPaths: [
+                "local-1.css",
+                "/local-2.css",
+                "http://external-1.css",
+                "https://external-2.css"
+            ]
+        ).render()
+
+        let expectedURLs = [
+            "/local-1.css",
+            "/local-2.css",
+            "http://external-1.css",
+            "https://external-2.css"
+        ]
+
+        for url in expectedURLs {
+            XCTAssertTrue(html.contains("""
+            <link rel="stylesheet" href="\(url)" type="text/css"/>
+            """))
+        }
+    }
+
     func testRenderingAudioPlayer() throws {
         let url = try require(URL(string: "https://audio.mp3"))
         let audio = Audio(url: url, format: .mp3)
@@ -59,6 +85,7 @@ final class PlotComponentTests: PublishTestCase {
 extension PlotComponentTests {
     static var allTests: Linux.TestList<PlotComponentTests> {
         [
+            ("testStylesheetPaths", testStylesheetPaths),
             ("testRenderingAudioPlayer", testRenderingAudioPlayer),
             ("testRenderingHostedVideoPlayer", testRenderingHostedVideoPlayer),
             ("testRenderingYouTubeVideoPlayer", testRenderingYouTubeVideoPlayer),


### PR DESCRIPTION
This patch makes the `Path` type preserve any external URL that it contains when calculating its `absoluteString` property. This is done by whitelisting the `http://` and `https://` prefixes, in order to be able to do things like load external stylesheets through Publish’s built-in Plot components.