### PR TITLE
Git deployment: Error handling post-merge fixes

### DIFF
--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -86,9 +86,7 @@ final class DeploymentTests: PublishTestCase {
         let remote = try container.createSubfolder(named: "Remote.git")
         let repo = try container.createSubfolder(named: "Repo")
 
-        try shellOut(to: [
-            "git init",
-        ], at: remote.path)
+        try shellOut(to: .gitInit(), at: remote.path)
         
         // First generate
         try publishWebsite(in: repo, using: [
@@ -98,15 +96,23 @@ final class DeploymentTests: PublishTestCase {
         // Then deploy
         CommandLine.arguments.append("--deploy")
 
-        XCTAssertThrowsError(
-            try publishWebsite(in: repo,
-                               using: [
-                                .deploy(using: .git(remote.path))
-            ]),
-            "Expected an error to be thrown") {
-                (error) in
-                XCTAssert(error is PublishingError)
+        var thrownError: PublishingError?
+
+        do {
+            try publishWebsite(
+                in: repo,
+                using: [.deploy(using: .git(remote.path))]
+            )
+        } catch {
+            thrownError = error as? PublishingError
         }
+
+        // We don't want to make too many assumptions about the way
+        // Git phrases its error messages here, so we just perform
+        // a few basic checks to make sure we have some form of output:
+        let infoMessage = try require(thrownError?.infoMessage)
+        XCTAssertTrue(infoMessage.contains("receive.denyCurrentBranch"))
+        XCTAssertTrue(infoMessage.contains("[remote rejected]"))
     }
 }
 


### PR DESCRIPTION
This patch fixes a few minor issues with the recent patch to make Git deployment errors propagate better to the user:

- Improve test code formatting.
- Make the test a bit more robust, by checking the contents of the error.