### PR TITLE
Fixed SectionID rawvalue bug in item.

### DIFF
--- a/Sources/Publish/API/Item.swift
+++ b/Sources/Publish/API/Item.swift
@@ -56,6 +56,6 @@ internal extension Item {
 
 private extension Item {
     func makeAbsolutePath() -> Path {
-        "\(sectionID)/\(relativePath)"
+        "\(sectionID.rawValue)/\(relativePath)"
     }
 }

--- a/Tests/PublishTests/Infrastructure/PublishTestCase.swift
+++ b/Tests/PublishTests/Infrastructure/PublishTestCase.swift
@@ -88,6 +88,7 @@ class PublishTestCase: XCTestCase {
             "one/index.html",
             "two/index.html",
             "three/index.html",
+            "custom-raw-value/index.html",
             "tags/index.html"
         ]
 

--- a/Tests/PublishTests/Infrastructure/WebsiteStub.swift
+++ b/Tests/PublishTests/Infrastructure/WebsiteStub.swift
@@ -10,7 +10,7 @@ import Plot
 
 class WebsiteStub {
     enum SectionID: String, WebsiteSectionID {
-        case one, two, three
+        case one, two, three, customRawValue = "custom-raw-value"
     }
 
     var url = URL(string: "https://swiftbysundell.com")!

--- a/Tests/PublishTests/Tests/HTMLGenerationTests.swift
+++ b/Tests/PublishTests/Tests/HTMLGenerationTests.swift
@@ -206,10 +206,12 @@ final class HTMLGenerationTests: PublishTestCase {
             expectedHTML: [
                 "one/index.html": "one",
                 "two/index.html": "two",
-                "three/index.html": "three"
+                "three/index.html": "three",
+                "custom-raw-value/index.html": "custom-raw-value"
             ]
         )
     }
+    
 
     func testNotGeneratingTagHTMLForIncompatibleTheme() throws {
         htmlFactory.makeTagListHTML = nil
@@ -225,6 +227,7 @@ final class HTMLGenerationTests: PublishTestCase {
                 "one/index.html": "",
                 "two/index.html": "",
                 "three/index.html": "",
+                "custom-raw-value/index.html": "",
                 "one/item/index.html": ""
             ],
             allowWhitelistedOutputFiles: false
@@ -245,6 +248,7 @@ final class HTMLGenerationTests: PublishTestCase {
                 "one/index.html": "",
                 "two/index.html": "",
                 "three/index.html": "",
+                "custom-raw-value/index.html": "",
                 "one/item/index.html": ""
             ],
             allowWhitelistedOutputFiles: false
@@ -257,6 +261,7 @@ final class HTMLGenerationTests: PublishTestCase {
 
         try publishWebsite(in: folder, using: [
             .addItem(Item.stub(withPath: "item").setting(\.tags, to: ["tag"])),
+            .addItem(Item.stub(withPath: "rawValueItem", sectionID: .customRawValue).setting(\.tags, to: ["tag"])),
             .generateHTML(withTheme: theme, fileMode: .standAloneFiles)
         ])
 
@@ -267,7 +272,9 @@ final class HTMLGenerationTests: PublishTestCase {
                 "one/index.html": "",
                 "two/index.html": "",
                 "three/index.html": "",
+                "custom-raw-value/index.html": "",
                 "one/item.html": "",
+                "custom-raw-value/rawValueItem.html": "",
                 "tags/index.html": "",
                 "tags/tag.html": ""
             ],

--- a/Tests/PublishTests/Tests/WebsiteTests.swift
+++ b/Tests/PublishTests/Tests/WebsiteTests.swift
@@ -27,6 +27,10 @@ final class WebsiteTests: PublishTestCase {
     func testPathForSectionID() {
         XCTAssertEqual(website.path(for: .one), "one")
     }
+    
+    func testPathForSectionIDWithRawValue() {
+        XCTAssertEqual(website.path(for: .customRawValue), "custom-raw-value")
+    }
 
     func testDefaultPathForTag() {
         let tag = Tag("some tag")
@@ -85,6 +89,7 @@ extension WebsiteTests {
             ("testDefaultTagListPath", testDefaultTagListPath),
             ("testCustomTagListPath", testCustomTagListPath),
             ("testPathForSectionID", testPathForSectionID),
+            ("testPathForSectionIDWithRawValue", testPathForSectionIDWithRawValue),
             ("testDefaultPathForTag", testDefaultPathForTag),
             ("testCustomPathForTag", testCustomPathForTag),
             ("testDefaultURLForTag", testDefaultURLForTag),


### PR DESCRIPTION

When making a multi-word SectionID it is necessary to set the rawvalue explicitly to for more standard urls.
Doing this caused two folders to be created in Output. If the SectionID was `case exampleSection = "example-section"`, Output would contain `example-section/index.hml` and `exampleSection/actualContents-of-folder-in-Content`