### PR TITLE
Foundation+Section: Improve section rendering

### DIFF
--- a/Resources/FoundationTheme/styles.css
+++ b/Resources/FoundationTheme/styles.css
@@ -51,6 +51,12 @@ nav {
 
 nav li {
     display: inline-block;
+    margin: 0 7px;
+    line-height: 1.5em;
+}
+
+nav li a.selected {
+    text-decoration: underline;
 }
 
 h1 {

--- a/Sources/Publish/API/Section.swift
+++ b/Sources/Publish/API/Section.swift
@@ -27,6 +27,7 @@ public struct Section<Site: Website>: Location {
 
     internal init(id: Site.SectionID) {
         self.id = id
+        self.title = id.rawValue.capitalized
     }
 }
 


### PR DESCRIPTION
This change adds a bit of margin between each section within the header of the built-in Foundation theme. It also increases the line height for those links to make them render nicely on smaller screens when a larger number of sections have been added, and makes the currently selected link underlined.

It also makes the default `title` of all sections become a capitalized version of their `rawValue`.