### PR TITLE
Mention front matter

### DIFF
--- a/Documentation/HowTo/custom-markdown-metadata-values.md
+++ b/Documentation/HowTo/custom-markdown-metadata-values.md
@@ -1,6 +1,6 @@
 # How to express custom metadata values using Markdown
 
-Publish enables each website to define its own site-specific item metadata, through its `Website.ItemMetadata` type. When adding items using Markdown, those values can then be expressed by adding a metadata header at the top of a file (commonly known as *front matter*).
+Publish enables each website to define its own site-specific item metadata, through its `Website.ItemMetadata` type. When adding items using Markdown, those values can then be expressed by adding a metadata header at the top of a file (within other tools referred to as *front matter*).
 
 Let’s say that we’re building an shopping website, and that we’ve defined a custom `productPrice` item metadata value, like this:
 

--- a/Documentation/HowTo/custom-markdown-metadata-values.md
+++ b/Documentation/HowTo/custom-markdown-metadata-values.md
@@ -1,6 +1,6 @@
 # How to express custom metadata values using Markdown
 
-Publish enables each website to define its own site-specific item metadata, through its `Website.ItemMetadata` type. When adding items using Markdown, those values can then be expressed by adding a metadata header at the top of a file.
+Publish enables each website to define its own site-specific item metadata, through its `Website.ItemMetadata` type. When adding items using Markdown, those values can then be expressed by adding a metadata header at the top of a file (commonly known as *front matter*).
 
 Let’s say that we’re building an shopping website, and that we’ve defined a custom `productPrice` item metadata value, like this:
 


### PR DESCRIPTION
The "header" in a markdown file is commonly known as Front Matter in many other static site generators. For people coming from other generators it would be useful to relate what Publish calls "metadata" to what they know as "front matter". It would also help for people that does a search about it.

I would also like to include a mention of this in the README but I don't think it fits anywhere in the current prose. 

Example of other well known generators using this wording:
- Gatsby https://www.gatsbyjs.org/docs/adding-markdown-pages/#frontmatter-for-metadata-in-markdown-files
- Jekyll https://jekyllrb.com/docs/front-matter/
- Hugo https://gohugo.io/content-management/front-matter/