### PR TITLE
Make CommandLine extension public

### DIFF
--- a/Sources/Publish/Internal/CommandLine+Output.swift
+++ b/Sources/Publish/Internal/CommandLine+Output.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal extension CommandLine {
+public extension CommandLine {
     enum OutputKind {
         case info
         case warning


### PR DESCRIPTION
One really nice thing about Publish is its command line output, showing each step of the pipeline and with fancy emojis:

```
Publishing Multiverse (6 steps)
[1/6] Copy 'Resources' files
[2/6] Add Markdown files from 'Content' folder
[3/6] Sort items
[4/6] Generate HTML
[5/6] Generate RSS feed
[6/6] Generate site map
✅ Successfully published Multiverse
```

But currently there is no way to reuse the code for this in our own Steps or Plugins, which makes it harder to add our own output in a way that maintains the style of Publish. 

I think that for Plugins this is crucial since it would be really nice to be able to integrate fully with Publish and offer the best end user experience. In my case I would like to display a nice error, see https://github.com/alexito4/ReadingTimePublishPlugin/pull/2.

This is a Draft, the only thing I've done is making the extension public, in order to get your views on this topic. If you're cool with it I can proceed by moving the file to the API folder and anything else you consider necessary (tests? docs?)