### PR TITLE
Handle capitalised default metadata keys

### DIFF
--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -33,6 +33,8 @@ public struct PublishingContext<Site: Website> {
     public var allTags: Set<Tag> { tagCache.tags ?? gatherAllTags() }
     /// Any date when the website was last generated.
     public private(set) var lastGenerationDate: Date?
+    /// Determines how metadata keys should be decoded from Markdown files
+    public var keyDecodingStrategy: MetadataKeyDecodingStrategy = .lowercase
 
     private let folders: Folder.Group
     private var tagCache = TagCache()
@@ -278,7 +280,8 @@ internal extension PublishingContext {
     func makeMarkdownContentFactory() -> MarkdownContentFactory<Site> {
         MarkdownContentFactory(
             parser: markdownParser,
-            dateFormatter: dateFormatter
+            dateFormatter: dateFormatter,
+            keyDecodingStrategy: keyDecodingStrategy
         )
     }
 

--- a/Sources/Publish/Internal/MarkdownContentFactory.swift
+++ b/Sources/Publish/Internal/MarkdownContentFactory.swift
@@ -12,6 +12,7 @@ import Codextended
 internal struct MarkdownContentFactory<Site: Website> {
     let parser: MarkdownParser
     let dateFormatter: DateFormatter
+    let keyDecodingStrategy: MetadataKeyDecodingStrategy
 
     func makeContent(fromFile file: File) throws -> Content {
         let markdown = try parser.parse(file.readAsString())
@@ -26,9 +27,10 @@ internal struct MarkdownContentFactory<Site: Website> {
         let decoder = makeMetadataDecoder(for: markdown)
 
         let metadata = try Site.ItemMetadata(from: decoder)
-        let tags = try decoder.decodeIfPresent("tags", as: [Tag].self)
+        let keys = MetadataKeys(with: keyDecodingStrategy)
+        let tags = try decoder.decodeIfPresent(keys.tags, as: [Tag].self)
         let content = try makeContent(fromMarkdown: markdown, file: file, decoder: decoder)
-        let rssProperties = try decoder.decodeIfPresent("rss", as: ItemRSSProperties.self)
+        let rssProperties = try decoder.decodeIfPresent(keys.rss, as: ItemRSSProperties.self)
 
         return Item(
             path: path,
@@ -40,7 +42,8 @@ internal struct MarkdownContentFactory<Site: Website> {
         )
     }
 
-    func makePage(fromFile file: File, at path: Path) throws -> Page {
+    func makePage(fromFile file: File,
+                  at path: Path) throws -> Page {
         let markdown = try parser.parse(file.readAsString())
         let decoder = makeMetadataDecoder(for: markdown)
         let content = try makeContent(fromMarkdown: markdown, file: file, decoder: decoder)
@@ -48,24 +51,60 @@ internal struct MarkdownContentFactory<Site: Website> {
     }
 }
 
+struct MetadataKeys {
+    var title: String = "title"
+    var description: String = "description"
+    var date: String = "date"
+    var image: String = "image"
+    var audio: String = "audio"
+    var video: String = "video"
+    var tags: String = "tags"
+    var rss: String = "rss"
+
+    init(with keyDecodingStrategy: MetadataKeyDecodingStrategy) {
+        switch keyDecodingStrategy {
+        case .capitalized:
+            self.title = self.title.capitalized
+            self.description = self.description.capitalized
+            self.date = self.date.capitalized
+            self.image = self.image.capitalized
+            self.audio = self.audio.capitalized
+            self.video = self.video.capitalized
+            self.tags = self.tags.capitalized
+            self.rss = self.rss.capitalized
+
+            // Handle .lowercase specifically, instead of using case default:, even though we don't do anything
+            // because we might add support for other decoding strategies in future
+            // and we want the compiler to force us to handle them specifically here
+        case .lowercase:
+            // This is the default case, so leave the keys with their default values
+            break
+        }
+    }
+}
+
 private extension MarkdownContentFactory {
     func makeMetadataDecoder(for markdown: Markdown) -> MarkdownMetadataDecoder {
         MarkdownMetadataDecoder(
             metadata: markdown.metadata,
-            dateFormatter: dateFormatter
+            dateFormatter: dateFormatter,
+            keyDecodingStrategy: keyDecodingStrategy
         )
     }
 
     func makeContent(fromMarkdown markdown: Markdown,
                      file: File,
                      decoder: MarkdownMetadataDecoder) throws -> Content {
-        let title = try decoder.decodeIfPresent("title", as: String.self)
-        let description = try decoder.decodeIfPresent("description", as: String.self)
-        let date = try resolvePublishingDate(fromFile: file, decoder: decoder)
+
+        let keys = MetadataKeys(with: keyDecodingStrategy)
+
+        let title = try decoder.decodeIfPresent(keys.title, as: String.self)
+        let description = try decoder.decodeIfPresent(keys.description, as: String.self)
+        let date = try resolvePublishingDate(fromFile: file, decoder: decoder, keys: keys)
         let lastModified = file.modificationDate ?? date
-        let imagePath = try decoder.decodeIfPresent("image", as: Path.self)
-        let audio = try decoder.decodeIfPresent("audio", as: Audio.self)
-        let video = try decoder.decodeIfPresent("video", as: Video.self)
+        let imagePath = try decoder.decodeIfPresent(keys.image, as: Path.self)
+        let audio = try decoder.decodeIfPresent(keys.audio, as: Audio.self)
+        let video = try decoder.decodeIfPresent(keys.video, as: Video.self)
 
         return Content(
             title: title ?? markdown.title ?? "",
@@ -80,8 +119,9 @@ private extension MarkdownContentFactory {
     }
 
     func resolvePublishingDate(fromFile file: File,
-                               decoder: MarkdownMetadataDecoder) throws -> Date {
-        if let date = try decoder.decodeIfPresent("date", as: Date.self) {
+                               decoder: MarkdownMetadataDecoder,
+                               keys: MetadataKeys) throws -> Date {
+        if let date = try decoder.decodeIfPresent(keys.date, as: Date.self) {
             return date
         }
 

--- a/Sources/Publish/Internal/MarkdownFileHandler.swift
+++ b/Sources/Publish/Internal/MarkdownFileHandler.swift
@@ -20,7 +20,6 @@ internal struct MarkdownFileHandler<Site: Website> {
                 throw wrap(error, forPath: "\(folder.path)index.md")
             }
         }
-
         for subfolder in folder.subfolders {
             guard let sectionID = Site.SectionID(rawValue: subfolder.name.lowercased()) else {
                 try addPagesForMarkdownFiles(


### PR DESCRIPTION
This PR is designed to support metadata keys in Markdown files that start with a capital letter, rather than being all lowercase. Coming from Pelican, all my files have capitalised metadata keys, and if we can support those, anyone switching from a similar setup won't need to convert their old files. It's still a WIP but I'd love to get some advice on how to move forward. Here's where I'm at:

1. I've created a `MetadataKeyDecodingStrategy` enum with values for `.lowercase` (default, all lowercase) and `.capitalized` (first letter of the key capitalised). The `PublishingContext` has `.lowercase` by default but this can be customised in a publishing step, just like setting a custom date formatter
2. I've written a test for handling capitalised _built-in_ metadata keys (i.e. date, description, audio, etc.) which is passing
3. I've created a struct to hold the built-in metadata keys so that a) the code base isn't full of hard-coded strings, and b) I can make that struct handle capitalising the underlying strings (or not) based on the `MetadataKeyDecodingStrategy` in use. I'm not 100% sure on this approach, and am open to suggestions, but the test is passing for this at least
4. I've written a test for handling capitalised _custom_ metadata keys, and this one is not passing yet. I'd love some advice on how to approach this
5. Part of handling custom capitalised keys was to change the way the `KeyMap` is created in `MarkdownMetadataDecoder`:

```swift
var key: Key?
switch keyDecodingStrategy {
    case .lowercase:
        key = Key(stringValue: stringKey)
    case .capitalized:
        key = Key(stringValue: stringKey.lowercased())
    }

if let key = key {
    evaluated.array.append(key)
    evaluated.set.insert(stringKey)
}
```

6. _But_ in my test, this code is not being hit, and the test is failing because this call: `let metadata = try Site.ItemMetadata(from: decoder)` inside `makeItem` uses the raw `Metadata` keys pulled directly from the Markdown. I'm wondering whether I might need to instead approach this by altering the actual `[String: String]` that's stored when parsing the Markdown, so that the raw keys are de-capitalised if needed before being stored, rather than trying to do this at a later step, such as in the code above where we're creating a `Key`. I _think_ if I stick with doing it at a later step, I'll need to keep the changes shown above, as well as adding changes to `ItemMetadata(from: decoder)`, but I may have misunderstood.
7. The last point to make is that this approach insists on the user knowing in advance which decoding strategy they want to use, and being consistent in just one strategy. I don't think this will be an issue, but it's worth mentioning. Another approach could be to always attempt to use the lowercase approach, and fall back to trying the capitalised (i.e. de-capitalising the raw keys from the Markdown) if the default approach doesn't work. This would mean the user doesn't have to set the key decoding strategy in advance, nor do they have to be consistent, but I think the code itself might be a little more messy that way, and I'm not sure it's necessary.

Hopefully that all makes sense! Very open to guidance on this.