### PR TITLE
[Draft] Introduce `.intermediate` folder and add support for `${variable}` substitution

### DIFF
--- a/Sources/Publish/API/PublishingStep.swift
+++ b/Sources/Publish/API/PublishingStep.swift
@@ -341,7 +341,12 @@ public extension PublishingStep {
 // MARK: - Generation
 
 public extension PublishingStep {
-            }
+    /// Substitutes variables in all intermediate files (including files in subfolders).
+    /// - Parameter configuration: Substitution configuration.
+    static func substituteVariables(using configuration: VariablesConfiguration) -> Self {
+        step(named: "Substitute variables") { context in
+            let substitution = VariablesSubstitution(configuration: configuration)
+            try substitution.recursivelySubstituteVariables(in: context.folders.intermediate)
         }
     }
 

--- a/Sources/Publish/API/Theme.swift
+++ b/Sources/Publish/API/Theme.swift
@@ -17,8 +17,7 @@ public struct Theme<Site: Website> {
     internal let makePageHTML: (Page, PublishingContext<Site>) throws -> HTML
     internal let makeTagListHTML: (TagListPage, PublishingContext<Site>) throws -> HTML?
     internal let makeTagDetailsHTML: (TagDetailsPage, PublishingContext<Site>) throws -> HTML?
-    internal let resourcePaths: Set<Path>
-    internal let creationPath: Path
+    internal let resources: ThemeResources
 
     /// Create a new theme instance.
     /// - parameter factory: The HTML factory to use to create the theme's HTML.
@@ -29,7 +28,7 @@ public struct Theme<Site: Website> {
     /// - parameter file: The file that this method is called from (auto-inserted).
     public init<T: HTMLFactory>(
         htmlFactory factory: T,
-        resourcePaths resources: Set<Path> = [],
+        resourcePaths: Set<Path> = [],
         file: StaticString = #file
     ) where T.Site == Site {
         makeIndexHTML = factory.makeIndexHTML
@@ -38,7 +37,14 @@ public struct Theme<Site: Website> {
         makePageHTML = factory.makePageHTML
         makeTagListHTML = factory.makeTagListHTML
         makeTagDetailsHTML = factory.makeTagDetailsHTML
-        resourcePaths = resources
-        creationPath = Path("\(file)")
+        self.resources = ThemeResources(
+            paths: resourcePaths,
+            themeCreationPath: Path("\(file)")
+        )
     }
+}
+
+internal struct ThemeResources {
+    internal let paths: Set<Path>
+    internal let themeCreationPath: Path
 }

--- a/Sources/Publish/API/VariablesSubstitution.swift
+++ b/Sources/Publish/API/VariablesSubstitution.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Files
+import ShellOut
+
+public struct VariablesConfiguration {
+    let variables: [String: String]
+    let fileExtensions: Set<String>
+
+    public init(variables: [String: String], in fileExtensions: Set<String>) {
+        self.variables = variables
+        self.fileExtensions = fileExtensions
+    }
+}
+
+internal struct VariablesSubstitution {
+    let configuration: VariablesConfiguration
+
+    func recursivelySubstituteVariables(in folder: Folder) throws {
+        try folder.files
+            .filter { configuration.fileExtensions.contains($0.extension ?? "") }
+            .forEach { file in try substituteVariables(in: file) }
+        try folder.subfolders.forEach { folder in try recursivelySubstituteVariables(in: folder) }
+    }
+
+    private func substituteVariables(in file: File) throws {
+        try configuration.variables.forEach { (variableName, variableValue) in
+            let newContent = try shellOut(to: "sed 's/${\(variableName)}/\(variableValue)/g' \(file.path)")
+            try file.write(newContent)
+        }
+    }
+}

--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -67,6 +67,7 @@ public extension Website {
     /// - parameter line: The line that this method is called from (auto-inserted).
     @discardableResult
     func publish(withTheme theme: Theme<Self>,
+                 variables variablesConfiguration: VariablesConfiguration? = nil,
                  indentation: Indentation.Kind? = nil,
                  at path: Path? = nil,
                  rssFeedSections: Set<SectionID> = Set(SectionID.allCases),
@@ -81,6 +82,7 @@ public extension Website {
                 .group(plugins.map(PublishingStep.installPlugin)),
                 .copyContentAndResourceFilesToIntermediateFolder(),
                 .copyThemeResourcesToIntermediateFolder(resources: theme.resources),
+                .unwrap(variablesConfiguration) { configuration in .substituteVariables(using: configuration) },
                 .optional(.copyResources()),
                 .addMarkdownFiles(),
                 .sortItems(by: \.date, order: .descending),

--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -79,6 +79,8 @@ public extension Website {
             at: path,
             using: [
                 .group(plugins.map(PublishingStep.installPlugin)),
+                .copyContentAndResourceFilesToIntermediateFolder(),
+                .copyThemeResourcesToIntermediateFolder(resources: theme.resources),
                 .optional(.copyResources()),
                 .addMarkdownFiles(),
                 .sortItems(by: \.date, order: .descending),
@@ -91,6 +93,7 @@ public extension Website {
                     )
                 },
                 .generateSiteMap(indentedBy: indentation),
+                .copyIntermediateOutputToFinalDestination(),
                 .unwrap(deploymentMethod, PublishingStep.deploy)
             ],
             file: file

--- a/Sources/Publish/Internal/Folder+Group.swift
+++ b/Sources/Publish/Internal/Folder+Group.swift
@@ -8,9 +8,15 @@ import Files
 
 internal extension Folder {
     struct Group {
-        let root: Folder
-        let output: Folder
+        /// Folder containing original contents to process (including `Contant/` and `Resources/` subfolders).
+        let source: Folder
+        /// `.intermediate` subfolder within `source`.
+        let intermediate: Folder
+        /// `Output` subfolder within `.intermediate`.
+        let intermediateOutput: Folder
+        /// `.internal` subfolder within `source`.
         let `internal`: Folder
+        /// `Caches` subfolder within `source`.
         let caches: Folder
     }
 }

--- a/Sources/Publish/Internal/HTMLGenerator.swift
+++ b/Sources/Publish/Internal/HTMLGenerator.swift
@@ -14,7 +14,6 @@ internal struct HTMLGenerator<Site: Website> {
     let context: PublishingContext<Site>
 
     func generate() throws {
-        try copyThemeResources()
         try generateIndexHTML()
         try generateSectionHTML()
         try generatePageHTML()
@@ -23,28 +22,6 @@ internal struct HTMLGenerator<Site: Website> {
 }
 
 private extension HTMLGenerator {
-    func copyThemeResources() throws {
-        guard !theme.resourcePaths.isEmpty else {
-            return
-        }
-
-        let creationFile = try File(path: theme.creationPath.string)
-        let packageFolder = try creationFile.resolveSwiftPackageFolder()
-
-        for path in theme.resourcePaths {
-            do {
-                let file = try packageFolder.file(at: path.string)
-                try context.copyFileToOutput(file, targetFolderPath: nil)
-            } catch {
-                throw PublishingError(
-                    path: path,
-                    infoMessage: "Failed to copy theme resource",
-                    underlyingError: error
-                )
-            }
-        }
-    }
-
     func generateIndexHTML() throws {
         let html = try theme.makeIndexHTML(context.index, context)
         let indexFile = try context.createOutputFile(at: "index.html")

--- a/Sources/PublishCLICore/ProjectGenerator.swift
+++ b/Sources/PublishCLICore/ProjectGenerator.swift
@@ -49,6 +49,7 @@ private extension ProjectGenerator {
         /.swiftpm
         /*.xcodeproj
         .publish
+        .intermediate
         """)
     }
 

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -67,7 +67,8 @@ final class DeploymentTests: PublishTestCase {
 
         // First generate
         try publishWebsite(in: repo, using: [
-            .generateHTML(withTheme: .foundation)
+            .generateHTML(withTheme: .foundation),
+            .copyIntermediateOutputToFinalDestination()
         ])
 
         // Then deploy

--- a/Tests/PublishTests/Tests/HTMLGenerationTests.swift
+++ b/Tests/PublishTests/Tests/HTMLGenerationTests.swift
@@ -296,24 +296,25 @@ final class HTMLGenerationTests: PublishTestCase {
             ]
         )
 
-        let siteIndex = try folder.file(at: "Output/index.html")
+        let intermediateFolder = try folder.subfolder(at: ".intermediate")
+        let siteIndex = try intermediateFolder.file(at: "Output/index.html")
         XCTAssertTrue(try siteIndex.readAsString().contains("WebsiteName"))
 
-        let sectionIndex = try folder.file(at: "Output/one/index.html")
+        let sectionIndex = try intermediateFolder.file(at: "Output/one/index.html")
         XCTAssertTrue(try sectionIndex.readAsString().contains("SectionTitle"))
 
-        let item = try folder.file(at: "Output/one/item/index.html")
+        let item = try intermediateFolder.file(at: "Output/one/item/index.html")
         XCTAssertTrue(try item.readAsString().contains("ItemTitle"))
 
-        let page = try folder.file(at: "Output/page/index.html")
+        let page = try intermediateFolder.file(at: "Output/page/index.html")
         XCTAssertTrue(try page.readAsString().contains("PageTitle"))
 
-        let tagList = try folder.file(at: "Output/tags/index.html")
+        let tagList = try intermediateFolder.file(at: "Output/tags/index.html")
         let tagListHTML = try tagList.readAsString()
         XCTAssertTrue(tagListHTML.contains("tagA"))
         XCTAssertTrue(tagListHTML.contains("tagB"))
 
-        let tagDetails = try folder.file(at: "Output/tags/taga/index.html")
+        let tagDetails = try intermediateFolder.file(at: "Output/tags/taga/index.html")
         XCTAssertTrue(try tagDetails.readAsString().contains("tagA"))
     }
 }

--- a/Tests/PublishTests/Tests/MarkdownTests.swift
+++ b/Tests/PublishTests/Tests/MarkdownTests.swift
@@ -115,10 +115,12 @@ final class MarkdownTests: PublishTestCase {
 
     func testParsingPageInNestedFolder() throws {
         let folder = try Folder.createTemporary()
-        let pageFile = try folder.createFile(at: "Content/my/custom/page.md")
-        try pageFile.write("# MyPage")
 
         let site = try publishWebsite(in: folder, using: [
+            .run { _ in
+                let pageFile = try folder.createFile(at: ".intermediate/Content/my/custom/page.md")
+                try pageFile.write("# MyPage")
+            },
             .addMarkdownFiles()
         ])
 
@@ -127,11 +129,13 @@ final class MarkdownTests: PublishTestCase {
 
     func testNotParsingNonMarkdownFiles() throws {
         let folder = try Folder.createTemporary()
-        try folder.createFile(at: "Content/image.png")
-        try folder.createFile(at: "Content/one/image.png")
-        try folder.createFile(at: "Content/custom/image.png")
 
         let site = try publishWebsite(in: folder, using: [
+            .run { _ in
+                try folder.createFile(at: ".intermediate/Content/image.png")
+                try folder.createFile(at: ".intermediate/Content/one/image.png")
+                try folder.createFile(at: ".intermediate/Content/custom/image.png")
+            },
             .addMarkdownFiles()
         ])
 

--- a/Tests/PublishTests/Tests/PodcastFeedGenerationTests.swift
+++ b/Tests/PublishTests/Tests/PodcastFeedGenerationTests.swift
@@ -20,7 +20,8 @@ final class PodcastFeedGenerationTests: PublishTestCase {
             "two/b": "# Not included"
         ])
 
-        let feed = try folder.file(at: "Output/feed.rss").readAsString()
+        let intermediateFolder = try folder.subfolder(at: ".intermediate")
+        let feed = try intermediateFolder.file(at: "Output/feed.rss").readAsString()
         XCTAssertTrue(feed.contains("Included"))
         XCTAssertFalse(feed.contains("Not included"))
     }
@@ -35,7 +36,8 @@ final class PodcastFeedGenerationTests: PublishTestCase {
             """
         ])
 
-        let feed = try folder.file(at: "Output/feed.rss").readAsString()
+        let intermediateFolder = try folder.subfolder(at: ".intermediate")
+        let feed = try intermediateFolder.file(at: "Output/feed.rss").readAsString()
         let substring = feed.substrings(between: "BEGIN ", and: " END").first
 
         XCTAssertEqual(substring, """
@@ -51,17 +53,18 @@ final class PodcastFeedGenerationTests: PublishTestCase {
         try contentFile.write(makeStubbedAudioMetadata())
 
         try generateFeed(in: folder)
-        let feedA = try folder.file(at: "Output/feed.rss").readAsString()
+        let intermediateFolder = try folder.subfolder(at: ".intermediate")
+        let feedA = try intermediateFolder.file(at: "Output/feed.rss").readAsString()
 
         let newDate = Date().addingTimeInterval(60 * 60)
         try generateFeed(in: folder, date: newDate)
-        let feedB = try folder.file(at: "Output/feed.rss").readAsString()
+        let feedB = try intermediateFolder.file(at: "Output/feed.rss").readAsString()
 
         XCTAssertEqual(feedA, feedB)
 
         try contentFile.append("New content")
         try generateFeed(in: folder, date: newDate)
-        let feedC = try folder.file(at: "Output/feed.rss").readAsString()
+        let feedC = try intermediateFolder.file(at: "Output/feed.rss").readAsString()
 
         XCTAssertNotEqual(feedB, feedC)
     }
@@ -72,13 +75,14 @@ final class PodcastFeedGenerationTests: PublishTestCase {
         try contentFile.write(makeStubbedAudioMetadata())
 
         try generateFeed(in: folder)
-        let feedA = try folder.file(at: "Output/feed.rss").readAsString()
+        let intermediateFolder = try folder.subfolder(at: ".intermediate")
+        let feedA = try intermediateFolder.file(at: "Output/feed.rss").readAsString()
 
         var newConfig = try makeConfigStub()
         newConfig.author.name = "New author name"
         let newDate = Date().addingTimeInterval(60 * 60)
         try generateFeed(in: folder, config: newConfig, date: newDate)
-        let feedB = try folder.file(at: "Output/feed.rss").readAsString()
+        let feedB = try intermediateFolder.file(at: "Output/feed.rss").readAsString()
 
         XCTAssertNotEqual(feedA, feedB)
     }
@@ -113,14 +117,15 @@ final class PodcastFeedGenerationTests: PublishTestCase {
             .addItem(itemA)
         ])
 
-        let feedA = try folder.file(at: "Output/feed.rss").readAsString()
+        let intermediateFolder = try folder.subfolder(at: ".intermediate")
+        let feedA = try intermediateFolder.file(at: "Output/feed.rss").readAsString()
 
         try generateFeed(in: folder, generationSteps: [
             .addItem(itemA),
             .addItem(itemB)
         ])
 
-        let feedB = try folder.file(at: "Output/feed.rss").readAsString()
+        let feedB = try intermediateFolder.file(at: "Output/feed.rss").readAsString()
         XCTAssertNotEqual(feedA, feedB)
     }
 }
@@ -170,6 +175,7 @@ private extension PodcastFeedGenerationTests {
         in folder: Folder,
         config: Configuration? = nil,
         generationSteps: [PublishingStep<Site>] = [
+            .copyContentAndResourceFilesToIntermediateFolder(),
             .addMarkdownFiles()
         ],
         date: Date = Date(),

--- a/Tests/PublishTests/Tests/SiteMapGenerationTests.swift
+++ b/Tests/PublishTests/Tests/SiteMapGenerationTests.swift
@@ -18,7 +18,8 @@ final class SiteMapGenerationTests: PublishTestCase {
             .generateSiteMap()
         ])
 
-        let file = try folder.file(at: "Output/sitemap.xml")
+        let intermediateFolder = try folder.subfolder(at: ".intermediate")
+        let file = try intermediateFolder.file(at: "Output/sitemap.xml")
         let siteMap = try file.readAsString()
 
         let expectedLocations = [
@@ -49,7 +50,8 @@ final class SiteMapGenerationTests: PublishTestCase {
             ])
         ])
 
-        let file = try folder.file(at: "Output/sitemap.xml")
+        let intermediateFolder = try folder.subfolder(at: ".intermediate")
+        let file = try intermediateFolder.file(at: "Output/sitemap.xml")
         let siteMap = try file.readAsString()
 
         let expectedLocations = [

--- a/Tests/PublishTests/Tests/VariablesSubstitutionTests.swift
+++ b/Tests/PublishTests/Tests/VariablesSubstitutionTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+import Files
+import Publish
+
+final class VariablesSubstitutionTests: PublishTestCase {
+    func testSubstitutingVariablesInFile() throws {
+        let folder = try Folder.createTemporary()
+
+        try publishWebsite(in: folder, using: [
+            .run { _ in
+                try folder
+                    .createFile(at: ".intermediate/index.md")
+                    .write("Hello ${name}, this is an example of ${count} variables substitution.")
+
+                try folder
+                    .createFile(at: ".intermediate/excluded.txt")
+                    .write("Hello ${name}, this file is excluded from substitution.")
+            },
+            .substituteVariables(
+                using: VariablesConfiguration(
+                    variables: [
+                        "name": "world",
+                        "count": "2"
+                    ],
+                    in: ["md"] // `.txt` file is not included
+                )
+            )
+        ])
+
+        XCTAssertEqual(
+            try folder.file(at: ".intermediate/index.md").readAsString(),
+            "Hello world, this is an example of 2 variables substitution."
+        )
+        XCTAssertEqual(
+            try folder.file(at: ".intermediate/excluded.txt").readAsString(),
+            "Hello ${name}, this file is excluded from substitution."
+        )
+    }
+}
+
+extension VariablesSubstitutionTests {
+    static var allTests: Linux.TestList<VariablesSubstitutionTests> {
+        [
+            ("testSubstitutingVariablesInFile", testSubstitutingVariablesInFile),
+        ]
+    }
+}
+


### PR DESCRIPTION
Hello everyone 👋,

for my website needs I made a draft of variables substitution feature. I'm proposing this as `[Draft]` pull request, as I made significant changes to publishing pipeline and I'm not happy with the current shape of my code. It does the work for me, but it needs some polishing to be production ready 🔨. 

**I want to hear community feedback on this proposal.** I'd love to work more on this if you like it.  

I start with some examples of the Variable Substitution feature. Then I discuss modifications to `PublishingPipeline` in more details.

## Basic example

By specifying variable name, value and file extension:
```swift
.publish(
   // ...
   variables: .init(
      variables: ["author" : "Maciek"],
      in: ["md"]
   ),
   // ...
)
```
all occurrences of `${author}` will be replaced with my name in all `*.md` files during website generation.

Variables can be used in all files involved into website generation:
* content files,
* website resources,
* theme resources.

## More advanced example

For my website I use variables to configure website colors in Swift code. This includes styles defined in `styles.css` as well as icon templates rendered as `.svg` files:
```css
// styles.css

body {
    background: ${website-background-color};
    color: ${website-text-color};
}
```
```xml
// github-icon.svg

<svg role="img" ...>...<path fill="${website-text-color}" d="..."/></svg>
```
This is my `.publish()` method:
```swift
struct Colors {
   let background = UIColor(hex: "#ecf0f1")
   let text = UIColor(hex: "#ecf0f1")
}

variables: .init(
    variables: [
        "website-background-color": colors.background.hexString,
        "website-text-color": colors.text.hexString,
    ],
    in: ["css", "svg"]
),
```

💡 By using variables substitution, we can have more centralised control over the website (and it's content) purely in Swift code.

## Publishing pipeline modification

Current implementation of `PublishingPipeline` doesn't leave a room for files pre- or post- processing. All generation steps (`.copyResources()`, `.addMarkdownFiles()` and `.generateHTML()`) read content directly from website root folders (`/Resources`, `/Content`, theme resources) and save results to `/Output` folder.

Current pipeline:
```
/source-folders
↓
generationSteps() → /Output
```

To make the room for pre-processing, in this PR introduces `.intermediate` folder into publishing pipeline. All source files are initially copied to `.intermediate` folder. All generation steps read and write to `.intermediate` folder. At the end of the pipeline, content of `.intermediate/Output` is copied to final `/Output` folder:

```
/source-folders
↓
/.intermediate
↓
preProcessingSteps() -> /.intermediate
↓
generationSteps() → /.intermediate/Output
↓
postProcessingSteps() -> /.intermediate/Output
↓
/Output
```

This is how it looks in code:
```swift
.copyContentAndResourceFilesToIntermediateFolder(),
.copyThemeResourcesToIntermediateFolder(resources: theme.resources),

// ... pre-processing steps modifying`.intermediate` files

// ... generation steps reading from`.intermediate` and writing to `.intermediate/Output`

// ... post-processing steps modifying`.intermediate/Output` files 

.copyIntermediateOutputToFinalDestination(),
```

The `.substituteVariables(using:)` is one example of pre-processing step.

While I strongly believe this pipeline design unlocks many interesting use cases 🚀, I know it introduces semantic dependency between steps. It's incorrect to run steps from one group before running the other. This complexity might be mitigated by adding _pipeline validator_ or _steps dependency resolver_ components in the future.

## Implementation details

This PR brings three significant changes:
* It introduces `.intermediate` folder where all files are copied right after starting publishing pipeline.
* It adds new `.substituteVariables(using configuration: VariablesConfiguration)` step which can be applied to files in `.intermediate` folder.
* It updates generation steps (`.copyResources()`, `.addMarkdownFiles()` and `.generateHTML()`) to read files from `.intermediate` folder.