### PR TITLE
Foundation theme: Render content body for pages

### DIFF
--- a/Sources/Publish/API/Theme+Foundation.swift
+++ b/Sources/Publish/API/Theme+Foundation.swift
@@ -91,9 +91,7 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
             .head(for: page, on: context.site),
             .body(
                 .header(for: context, selectedSection: nil),
-                .wrapper(
-
-                ),
+                .wrapper(.contentBody(page.body)),
                 .footer(for: context.site)
             )
         )


### PR DESCRIPTION
Was previously missing from the built-in Foundation theme.