### PR TITLE
Clarify documentation around deploying

### DIFF
--- a/Documentation/HowTo/deploying-on-every-generation.md
+++ b/Documentation/HowTo/deploying-on-every-generation.md
@@ -44,3 +44,5 @@ try MyWebsite().publish(using: [
 ```
 
 The `deployWhileGenerating(using: )` step will take in any defined deployment method, including the built in `.git()` method and any others you've defined customly. 
+
+*Again, anytime you use this step, it is deploying the site in whatever state it is after generation, which could be drastically different from what you want. **Use this with extreme caution***

--- a/Documentation/HowTo/deploying-on-every-generation.md
+++ b/Documentation/HowTo/deploying-on-every-generation.md
@@ -1,0 +1,46 @@
+# How to deploy the site on every generation
+
+Let's say you live on the wild side, and you don't develop locally for some reason. Maybe you work with a team. Maybe all of your assets are stored on your server, and you have a love for relative links. Maybe you develop on the server.
+
+Currently, the only official way to deploy is:
+
+1. Generating your site with `publish generate` or by running the Package with no command line flags
+2. Deploying by running `publish deploy` or by running the Package with the command line flag `-d` or `--deploy`
+
+This is so that when you like what you've generated, you deploy it. You don't want to run the risk of regenerating the site, only to realize you changed something and broke it all.
+
+**But what if you're the kind of person mentioned above?**
+
+Well, don't fret. There is a way to deploy on every generation, as part of the generation process.
+
+*Be warned, this ignores the risk of a regeneration breaking something then immediately deploying that broken site. It is recommended that you don't do this unless you're sure you really want to. **Make backups frequently.***
+
+### Create a new publishing step for the deployment
+
+To do this, you'll need to extend `PublishingStep` and add a new function that takes in a `DeploymentMethod<Site>` and returns a `step()`
+
+Here's an example:
+```swift
+public extension PublishingStep {
+    /// Deploy the website using a given method.
+    /// - warning: This will run on every generation, regardless of command line flags.
+    /// - parameter method: The method to use when deploying the website.
+    static func deployWhileGenerating(using method: DeploymentMethod<Site>) -> Self {
+        step(named: "Deploy using \(method.name)") { context in
+            try method.body(context)
+        }
+    }
+}
+```
+
+### Use the new publishing step
+
+Now you need to actually use this new step you just defined. Here's an example of the step defined above in use:
+```swift
+try MyWebsite().publish(using: [
+    ...
+    .deployWhileGenerating(using: .git("origin"))
+])
+```
+
+The `deployWhileGenerating(using: )` step will take in any defined deployment method, including the built in `.git()` method and any others you've defined customly. 

--- a/Documentation/HowTo/deploying-on-every-generation.md
+++ b/Documentation/HowTo/deploying-on-every-generation.md
@@ -13,7 +13,7 @@ This is so that when you like what you've generated, you deploy it. You don't wa
 
 Well, don't fret. There is a way to deploy on every generation, as part of the generation process.
 
-*Be warned, this ignores the risk of a regeneration breaking something then immediately deploying that broken site. It is recommended that you don't do this unless you're sure you really want to. **Make backups frequently.***
+*Be warned, this dangerously ignores the risk of a regeneration breaking something then immediately deploying that broken site. It is recommended that you don't do this unless you're sure you really want to. **Make backups frequently.***
 
 ### Create a new publishing step for the deployment
 

--- a/Documentation/HowTo/deploying-on-every-generation.md
+++ b/Documentation/HowTo/deploying-on-every-generation.md
@@ -17,7 +17,7 @@ Well, don't fret. There is a way to deploy on every generation, as part of the g
 
 ### Create a new publishing step for the deployment
 
-To do this, you'll need to extend `PublishingStep` and add a new function that takes in a `DeploymentMethod<Site>` and returns a `step()`
+To do this, you'll need to extend `PublishingStep` and add a new function that takes in a `DeploymentMethod<Site>` and returns a `step()`.
 
 Here's an example:
 ```swift

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -11,5 +11,6 @@ Shorter articles focused on explaining how to get a given task done using Publis
 - [Adding Swift syntax highlighting to Markdown code blocks](HowTo/adding-swift-syntax-highlighting.md)
 - [Nesting items within folders](HowTo/nested-items.md)
 - [Using a custom `DateFormatter`](HowTo/using-a-custom-date-formatter.md)
+- [Deploying on every generation](HowTo/deploying-on-every-generation.md)
 
 *Contributions adding more “How to” articles, or other kinds of documentation, are more than welcome.*

--- a/README.md
+++ b/README.md
@@ -273,7 +273,9 @@ try DeliciousRecipes().publish(using: [
 ])
 ```
 
-Even when added to a pipeline, deployment steps are disabled by default, and are only executed when the `--deploy` command line flag was passed (which can be added through Xcode’s `Product > Scheme > Edit Scheme...` menu), or by running the command line tool using `publish deploy`.
+Even when added to a pipeline, deployment steps are disabled by default, and are only executed when the `--deploy` command line flag was passed (which can be added through Xcode’s `Product > Scheme > Edit Scheme...` menu), or by running the command line tool using `publish deploy`. 
+
+*Note: Running `publish deploy` or with the `--deploy` command line flag runs **only** the deployment steps. It doesn't generate the site before deploying, to save time when deploying.*
 
 Publish can also start a `localhost` web server for local testing and development, by using the `publish run` command. To regenerate site content with the server running, use Product > Run on your site's package in Xcode.
 


### PR DESCRIPTION
This clarifies the documentation around deploying. It states that deploying doesn't regenerate the site. 

Also, this adds a how-to for deploying on generation, with plenty of warnings. 