### PR TITLE
SectionMap: Make iteration order predictable

### DIFF
--- a/Sources/Publish/API/SectionMap.swift
+++ b/Sources/Publish/API/SectionMap.swift
@@ -28,6 +28,11 @@ public struct SectionMap<Site: Website> {
 
 extension SectionMap: Sequence {
     public func makeIterator() -> AnyIterator<Section<Site>> {
-        AnyIterator(sections.values.makeIterator())
+        var ids = self.ids.makeIterator()
+
+        return AnyIterator {
+            guard let nextID = ids.next() else { return nil }
+            return self[nextID]
+        }
     }
 }

--- a/Tests/PublishTests/Infrastructure/LinuxCompatibility.swift
+++ b/Tests/PublishTests/Infrastructure/LinuxCompatibility.swift
@@ -31,6 +31,8 @@ internal extension Linux {
 #if canImport(ObjectiveC)
 internal final class LinuxVerificationTests: XCTestCase {
     func testAllTestsRunOnLinux() {
+        var totalLinuxTestCount = 0
+
         for testCase in allTests() {
             let type = testCase.testCaseClass
 
@@ -49,7 +51,19 @@ internal final class LinuxVerificationTests: XCTestCase {
                     """)
                 }
             }
+
+            totalLinuxTestCount += linuxTestNames.count
         }
+
+        XCTAssertEqual(
+            XCTestSuite.default.testCaseCount - 1,
+            totalLinuxTestCount,
+            """
+            Linux and Apple Platforms test counts are not equal.
+            Perhaps you added a new test case class?
+            If so, you need to add it in XCTestManifests.swift.
+            """
+        )
     }
 }
 #endif

--- a/Tests/PublishTests/Infrastructure/XCTestManifests.swift
+++ b/Tests/PublishTests/Infrastructure/XCTestManifests.swift
@@ -15,9 +15,11 @@ public func allTests() -> [Linux.TestCase] {
         Linux.makeTestCase(using: FileIOTests.allTests),
         Linux.makeTestCase(using: HTMLGenerationTests.allTests),
         Linux.makeTestCase(using: MarkdownTests.allTests),
+        Linux.makeTestCase(using: PathTests.allTests),
         Linux.makeTestCase(using: PlotComponentTests.allTests),
         Linux.makeTestCase(using: PluginTests.allTests),
         Linux.makeTestCase(using: PodcastFeedGenerationTests.allTests),
+        Linux.makeTestCase(using: PublishingContextTests.allTests),
         Linux.makeTestCase(using: RSSFeedGenerationTests.allTests),
         Linux.makeTestCase(using: SiteMapGenerationTests.allTests),
         Linux.makeTestCase(using: WebsiteTests.allTests)

--- a/Tests/PublishTests/Tests/PublishingContextTests.swift
+++ b/Tests/PublishTests/Tests/PublishingContextTests.swift
@@ -1,0 +1,33 @@
+/**
+*  Publish
+*  Copyright (c) John Sundell 2020
+*  MIT license, see LICENSE file for details
+*/
+
+import XCTest
+import Publish
+
+final class PublishingContextTests: PublishTestCase {
+    func testSectionIterationOrder() throws {
+        let expectedOrder = WebsiteStub.SectionID.allCases
+        var actualOrder = [WebsiteStub.SectionID]()
+
+        try publishWebsite(using: [
+            .step(named: "Step") { context in
+                context.sections.forEach { section in
+                    actualOrder.append(section.id)
+                }
+            }
+        ])
+
+        XCTAssertEqual(expectedOrder, actualOrder)
+    }
+}
+
+extension PublishingContextTests {
+    static var allTests: Linux.TestList<PublishingContextTests> {
+        [
+            ("testSectionIterationOrder", testSectionIterationOrder)
+        ]
+    }
+}


### PR DESCRIPTION
This change makes the order in which sections are iterated over predictable. Before, a dictionary value iterator was used, which doesn’t guarantee any particular order. Now, sections are always iterated over in the order their IDs were defined in the current site’s `Website.SectionID` enum.

(Also includes some minor tweaks to ensure that all tests run on Linux).