### PR TITLE
RSS: Add option to specify title suffixes for items

### DIFF
--- a/Sources/Publish/API/Item.swift
+++ b/Sources/Publish/API/Item.swift
@@ -50,7 +50,9 @@ public struct Item<Site: Website>: AnyItem, Hashable {
 
 internal extension Item {
     var rssTitle: String {
-        (rssProperties.titlePrefix ?? "") + title
+        let prefix = rssProperties.titlePrefix ?? ""
+        let suffix = rssProperties.titleSuffix ?? ""
+        return prefix + title + suffix
     }
 }
 

--- a/Sources/Publish/API/ItemRSSProperties.swift
+++ b/Sources/Publish/API/ItemRSSProperties.swift
@@ -14,12 +14,16 @@ public struct ItemRSSProperties: Codable, Hashable {
     public var guid: String?
     /// Any prefix that should be added to the item's title within an RSS feed.
     public var titlePrefix: String?
+    /// Any suffix that should be added to the item's title within an RSS feed.
+    public var titleSuffix: String?
 
     /// Initialize an instance of this type
-    /// - Parameter guid: Any specific GUID that should be added for the item.
-    /// - Parameter titlePrefix: Any prefix that should be added to the item's title.
+    /// - parameter guid: Any specific GUID that should be added for the item.
+    /// - parameter titlePrefix: Any prefix that should be added to the item's title.
+    /// - parameter titleSuffix: Any suffix that should be added to the item's title.
     public init(guid: String? = nil,
-                titlePrefix: String? = nil) {
+                titlePrefix: String? = nil,
+                titleSuffix: String? = nil) {
         self.guid = guid
         self.titlePrefix = titlePrefix
     }

--- a/Tests/PublishTests/Tests/PodcastFeedGenerationTests.swift
+++ b/Tests/PublishTests/Tests/PodcastFeedGenerationTests.swift
@@ -45,6 +45,25 @@ final class PodcastFeedGenerationTests: PublishTestCase {
         """)
     }
 
+    func testItemPrefixAndSuffix() throws {
+        let folder = try Folder.createTemporary()
+
+        let prefixSuffix = """
+        rss.titlePrefix: Prefix
+        rss.titleSuffix: Suffix
+        """
+
+        try generateFeed(in: folder, content: [
+            "one/item.md": """
+            \(makeStubbedAudioMetadata(including: prefixSuffix))
+            # Title
+            """
+        ])
+
+        let feed = try folder.file(at: "Output/feed.rss").readAsString()
+        XCTAssertTrue(feed.contains("<title>PrefixTitleSuffix</title>"))
+    }
+
     func testReusingPreviousFeedIfNoItemsWereModified() throws {
         let folder = try Folder.createTemporary()
         let contentFile = try folder.createFile(at: "Content/one/item.md")
@@ -130,6 +149,7 @@ extension PodcastFeedGenerationTests {
         [
             ("testOnlyIncludingSpecifiedSection", testOnlyIncludingSpecifiedSection),
             ("testConvertingRelativeLinksToAbsolute", testConvertingRelativeLinksToAbsolute),
+            ("testItemPrefixAndSuffix", testItemPrefixAndSuffix),
             ("testReusingPreviousFeedIfNoItemsWereModified", testReusingPreviousFeedIfNoItemsWereModified),
             ("testNotReusingPreviousFeedIfConfigChanged", testNotReusingPreviousFeedIfConfigChanged),
             ("testNotReusingPreviousFeedIfItemWasAdded", testNotReusingPreviousFeedIfItemWasAdded)
@@ -156,12 +176,13 @@ private extension PodcastFeedGenerationTests {
         )
     }
 
-    func makeStubbedAudioMetadata() -> String {
+    func makeStubbedAudioMetadata(including additionalString: String = "") -> String {
         """
         ---
         audio.url: https://audio.mp3
         audio.duration: 05:02
         audio.size: 12345
+        \(additionalString)
         ---
         """
     }

--- a/Tests/PublishTests/Tests/RSSFeedGenerationTests.swift
+++ b/Tests/PublishTests/Tests/RSSFeedGenerationTests.swift
@@ -42,6 +42,23 @@ final class RSSFeedGenerationTests: PublishTestCase {
         """)
     }
 
+    func testItemPrefixAndSuffix() throws {
+        let folder = try Folder.createTemporary()
+
+        try generateFeed(in: folder, content: [
+            "one/item.md": """
+            ---
+            rss.titlePrefix: Prefix
+            rss.titleSuffix: Suffix
+            ---
+            # Title
+            """
+        ])
+
+        let feed = try folder.file(at: "Output/feed.rss").readAsString()
+        XCTAssertTrue(feed.contains("<title>PrefixTitleSuffix</title>"))
+    }
+
     func testReusingPreviousFeedIfNoItemsWereModified() throws {
         let folder = try Folder.createTemporary()
         let contentFile = try folder.createFile(at: "Content/one/item.md")
@@ -103,6 +120,7 @@ extension RSSFeedGenerationTests {
         [
             ("testOnlyIncludingSpecifiedSections", testOnlyIncludingSpecifiedSections),
             ("testConvertingRelativeLinksToAbsolute", testConvertingRelativeLinksToAbsolute),
+            ("testItemPrefixAndSuffix", testItemPrefixAndSuffix),
             ("testReusingPreviousFeedIfNoItemsWereModified", testReusingPreviousFeedIfNoItemsWereModified),
             ("testNotReusingPreviousFeedIfConfigChanged", testNotReusingPreviousFeedIfConfigChanged),
             ("testNotReusingPreviousFeedIfItemWasAdded", testNotReusingPreviousFeedIfItemWasAdded)


### PR DESCRIPTION
This change adds a new `titleSuffix` property to `ItemRSSProperties` which, just like `titlePrefix`, enables a string to be attached to an item’s title when it’s being rendered as part of an RSS/podcast feed.