### PR TITLE
Make stop server instruction clear

### DIFF
--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -24,7 +24,7 @@ internal struct WebsiteRunner {
         print("""
         🌍 Starting web server at http://localhost:\(portNumber)
 
-        Press any key to stop the server and exit
+        Press ENTER to stop the server and exit
         """)
 
         serverQueue.async {


### PR DESCRIPTION
When running `publish run`, pressing any key won't stop the server. Should make the instruction clearer.