### PR TITLE
Ensure that all images to which pages have relative links exist

### DIFF
--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -81,6 +81,7 @@ public extension Website {
                 .group(plugins.map(PublishingStep.installPlugin)),
                 .optional(.copyResources()),
                 .addMarkdownFiles(),
+                .ensureAllImagesExist(),
                 .sortItems(by: \.date, order: .descending),
                 .group(additionalSteps),
                 .generateHTML(withTheme: theme, indentation: indentation),


### PR DESCRIPTION
This PR adds a new publishing step that checks whether all images to which pages have relative links exist. 

I am definitely going to add the tests, but I'm not sure where is the appropriate location for them. I suppose that `ErrorTests` is a good place for cases when `.ensureAllImagesExist()` step should fail, but I have no idea in which file "happy path" test case should be placed.

Also, I am not sure, should the default publishing pipeline contain this step.

And maybe this step should check not only images but local resources of other types too.

What do you think, @JohnSundell ?