### PR TITLE
Improve asSiteName extension

### DIFF
--- a/Sources/PublishCLICore/ProjectGenerator.swift
+++ b/Sources/PublishCLICore/ProjectGenerator.swift
@@ -19,7 +19,7 @@ internal struct ProjectGenerator {
         self.folder = folder
         self.publishRepositoryURL = publishRepositoryURL
         self.publishVersion = publishVersion
-        self.siteName = folder.name.asSiteName()
+        self.siteName = folder.name.asSiteName
     }
 
     func generate() throws {
@@ -154,12 +154,21 @@ private extension Folder {
 }
 
 private extension String {
-    func asSiteName() -> Self {
-        let letters = filter { $0.isLetter }
-        guard !letters.isEmpty else {
+    var asSiteName: Self {
+        let validCharacters = CharacterSet.alphanumerics
+        let validEdgeCharacters = CharacterSet.letters
+        let validSegments = trimmingCharacters(in: validEdgeCharacters.inverted)
+            .components(separatedBy: validCharacters.inverted)
+
+        guard
+            let firstSegment = validSegments.first,
+            !firstSegment.isEmpty else {
             return "SiteName"
         }
-        return String(letters).capitalizingFirstLetter()
+
+        return validSegments
+            .map { $0.capitalizingFirstLetter() }
+            .joined()
     }
     
     private func capitalizingFirstLetter() -> String {

--- a/Sources/PublishCLICore/ProjectGenerator.swift
+++ b/Sources/PublishCLICore/ProjectGenerator.swift
@@ -19,7 +19,7 @@ internal struct ProjectGenerator {
         self.folder = folder
         self.publishRepositoryURL = publishRepositoryURL
         self.publishVersion = publishVersion
-        self.siteName = folder.name.asSiteName
+        self.siteName = folder.name.asSiteName()
     }
 
     func generate() throws {
@@ -154,7 +154,7 @@ private extension Folder {
 }
 
 private extension String {
-    var asSiteName: Self {
+    func asSiteName() -> Self {
         let validCharacters = CharacterSet.alphanumerics
         let validEdgeCharacters = CharacterSet.letters
         let validSegments = trimmingCharacters(in: validEdgeCharacters.inverted)

--- a/Tests/PublishTests/Tests/CLITests.swift
+++ b/Tests/PublishTests/Tests/CLITests.swift
@@ -49,12 +49,20 @@ final class CLITests: PublishTestCase {
         XCTAssertEqual(try folder.getPackageName(), "CamelCaseName")
         #endif
     }
+
+    func testSiteNameWithNonLetterValidCharactersFolderName() throws {
+        #if INCLUDE_CLI
+        let folder = try Folder.createTemporary(named: "Blog.CamelCaseName2.com")
+        try makeCLI(in: folder, command: "new").run(in: folder)
+        XCTAssertEqual(try folder.getPackageName(), "BlogCamelCaseName2Com")
+        #endif
+    }
     
     func testSiteNameFromFolderNameWithNonLetters() throws {
         #if INCLUDE_CLI
         let folder = try Folder.createTemporary(named: "My website 1")
         try makeCLI(in: folder, command: "new").run(in: folder)
-        XCTAssertEqual(try folder.getPackageName(), "Mywebsite")
+        XCTAssertEqual(try folder.getPackageName(), "MyWebsite")
         #endif
     }
     
@@ -76,6 +84,7 @@ extension CLITests {
             ("testSiteNameFromLowercasedFolderName", testSiteNameFromLowercasedFolderName),
             ("testSiteNameFromFolderNameStartingWithDigit", testSiteNameFromFolderNameStartingWithDigit),
             ("testSiteNameFromCamelCaseFolderName", testSiteNameFromCamelCaseFolderName),
+            ("testSiteNameWithNonLetterValidCharactersFolderName", testSiteNameWithNonLetterValidCharactersFolderName),
             ("testSiteNameFromFolderNameWithNonLetters", testSiteNameFromFolderNameWithNonLetters),
             ("testSiteNameFromDigitsOnlyFolderName", testSiteNameFromDigitsOnlyFolderName)
         ]


### PR DESCRIPTION
Hey John. First of all, thanks for all the contributions you've been doing for the community. You're truly an inspiration for many of us :hats-off:

This PR does the following:

* while trailing digits aren't valid (according to the existing tests I found), digits in the middle of the string should be valid in my opinion. For example: `Give2Charity` shouldn't have the `2` removed.
* when removing invalid characters, as dashes or underscores, the following character is capitalized. For example, `blog.somename.com` becomes `BlogSomenameCom`. The same is valid for a space or any other non-alphanumeric character.
* converts `asSiteName` to a variable, as it makes more sense in this case than a function

I've added a test and modified one existing to match the new behavior.