### PR TITLE
Determine which Python server command to use based on Python version

### DIFF
--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -63,12 +63,12 @@ private extension WebsiteRunner {
         }
     }
 
-    func resolveSystemPythonMajorVersionNumber() -> Int? {
+    func resolveSystemPythonMajorVersionNumber() -> Int {
         // Expected output: `Python X.X.X`
         let pythonVersionString = try? shellOut(to: "python --version")
         let fullVersionNumber = pythonVersionString?.split(separator: " ").last
         let majorVersionNumber = fullVersionNumber?.first
-        return majorVersionNumber?.wholeNumberValue
+        return majorVersionNumber?.wholeNumberValue ?? 2
     }
 
     func outputServerErrorMessage(_ message: String) {

--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -30,7 +30,7 @@ internal struct WebsiteRunner {
         serverQueue.async {
             do {
                 _ = try shellOut(
-                    to: "python -m \(self.getPythonHTTPServerCommand()) \(self.portNumber)",
+                    to: "python -m \(self.resolvePythonHTTPServerCommand()) \(self.portNumber)",
                     at: outputFolder.path,
                     process: serverProcess
                 )
@@ -55,16 +55,17 @@ private extension WebsiteRunner {
         catch { throw CLIError.outputFolderNotFound }
     }
 
-    func getPythonHTTPServerCommand() -> String {
-        if getSystemPythonMajorVersionNumber() == 3 {
+    func resolvePythonHTTPServerCommand() -> String {
+        if resolveSystemPythonMajorVersionNumber() >= 3 {
             return "http.server"
         } else {
             return "SimpleHTTPServer"
         }
     }
 
-    func getSystemPythonMajorVersionNumber() -> Int? {
-        let pythonVersionString = try? shellOut(to: "python --version") // expected output: `Python X.X.X`
+    func resolveSystemPythonMajorVersionNumber() -> Int? {
+        // Expected output: `Python X.X.X`
+        let pythonVersionString = try? shellOut(to: "python --version")
         let fullVersionNumber = pythonVersionString?.split(separator: " ").last
         let majorVersionNumber = fullVersionNumber?.first
         return majorVersionNumber?.wholeNumberValue


### PR DESCRIPTION
I currently have the `python` shell command bound to Python 3 on my system. The `SimpleHTTPServer` command has been deprecated in Python 3, in favor of `http.server` instead. This change calls the appropriate command depending on which version of Python is being run on the system.

Let me know if there are any changes or additions you'd like to see made. Thanks!