### PR TITLE
Clean Output folder including hidden files

### DIFF
--- a/Sources/Publish/Internal/PublishingPipeline.swift
+++ b/Sources/Publish/Internal/PublishingPipeline.swift
@@ -86,7 +86,7 @@ private extension PublishingPipeline {
         let outputFolderName = "Output"
 
         if shouldEmptyOutputFolder {
-            try? root.subfolder(named: outputFolderName).empty()
+            try? root.subfolder(named: outputFolderName).empty(includingHidden: true)
         }
 
         do {

--- a/Tests/PublishTests/Tests/FileIOTests.swift
+++ b/Tests/PublishTests/Tests/FileIOTests.swift
@@ -122,6 +122,19 @@ final class FileIOTests: PublishTestCase {
 
         XCTAssertEqual(itemFile?.name, "index.html")
     }
+
+    func testCleanHiddenFilesInOutputFolder() throws {
+        let folder = try Folder.createTemporary()
+        try folder.createFile(at: "Output/.hidden")
+        try folder.createFile(at: ".hidden").write("Hello, world!")
+
+        try publishWebsite(in: folder, using: [
+            .copyFile(at: ".hidden")
+        ])
+
+        let file = try folder.file(at: "Output/.hidden")
+        XCTAssertEqual(try file.readAsString(), "Hello, world!")
+    }
 }
 
 extension FileIOTests {
@@ -134,7 +147,8 @@ extension FileIOTests {
             ("testCopyingResourcesWithoutFolder", testCopyingResourcesWithoutFolder),
             ("testCreatingRootLevelFolder", testCreatingRootLevelFolder),
             ("testRetrievingOutputFolder", testRetrievingOutputFolder),
-            ("testRetrievingOutputFile", testRetrievingOutputFile)
+            ("testRetrievingOutputFile", testRetrievingOutputFile),
+            ("testCleanHiddenFilesInOutputFolder", testCleanHiddenFilesInOutputFolder)
         ]
     }
 }

--- a/Tests/PublishTests/Tests/FileIOTests.swift
+++ b/Tests/PublishTests/Tests/FileIOTests.swift
@@ -126,14 +126,12 @@ final class FileIOTests: PublishTestCase {
     func testCleanHiddenFilesInOutputFolder() throws {
         let folder = try Folder.createTemporary()
         try folder.createFile(at: "Output/.hidden")
-        try folder.createFile(at: ".hidden").write("Hello, world!")
 
         try publishWebsite(in: folder, using: [
-            .copyFile(at: ".hidden")
+            .step(named: "Do nothing") { _ in }
         ])
 
-        let file = try folder.file(at: "Output/.hidden")
-        XCTAssertEqual(try file.readAsString(), "Hello, world!")
+        XCTAssertFalse(folder.containsFile(named: "Output/.hidden"))
     }
 }
 

--- a/Tests/PublishTests/Tests/FileIOTests.swift
+++ b/Tests/PublishTests/Tests/FileIOTests.swift
@@ -123,7 +123,7 @@ final class FileIOTests: PublishTestCase {
         XCTAssertEqual(itemFile?.name, "index.html")
     }
 
-    func testCleanHiddenFilesInOutputFolder() throws {
+    func testCleaningHiddenFilesInOutputFolder() throws {
         let folder = try Folder.createTemporary()
         try folder.createFile(at: "Output/.hidden")
 
@@ -146,7 +146,7 @@ extension FileIOTests {
             ("testCreatingRootLevelFolder", testCreatingRootLevelFolder),
             ("testRetrievingOutputFolder", testRetrievingOutputFolder),
             ("testRetrievingOutputFile", testRetrievingOutputFile),
-            ("testCleanHiddenFilesInOutputFolder", testCleanHiddenFilesInOutputFolder)
+            ("testCleaningHiddenFilesInOutputFolder", testCleaningHiddenFilesInOutputFolder)
         ]
     }
 }


### PR DESCRIPTION
Hi, I want copy hidden files from Resources folder (for example: .htaccess) to Output folder. Problem is that `PublishingPipeline.setUpFolders` not removes hidden files.

This PR fix the cleaning step. If you agree I also add hidden files copying to copy file publishing steps.

Copy hidden files can be done in many variants:
* automatic copy hidden files by modify `folder.files` to `folder.files.includingHidden` in `PublishingStep.copyFiles`
* add parameter `includingHidde: Bool` to functions `PublishingStep.copyResources` and `PublishingStep.copyFiles`

