### PR TITLE
Use filename as fallback for Markdown content title

### DIFF
--- a/Sources/Publish/Internal/MarkdownContentFactory.swift
+++ b/Sources/Publish/Internal/MarkdownContentFactory.swift
@@ -69,7 +69,7 @@ private extension MarkdownContentFactory {
         let video = try decoder.decodeIfPresent("video", as: Video.self)
 
         return Content(
-            title: title ?? markdown.title ?? "",
+            title: title ?? markdown.title ?? file.nameExcludingExtension,
             description: description ?? "",
             body: Content.Body(html: markdown.html),
             date: date,

--- a/Tests/PublishTests/Tests/MarkdownTests.swift
+++ b/Tests/PublishTests/Tests/MarkdownTests.swift
@@ -26,7 +26,7 @@ final class MarkdownTests: PublishTestCase {
         XCTAssertEqual(item.title, "Overridden title")
     }
 
-	func testParsingFileWithNoTitle() throws {
+    func testParsingFileWithNoTitle() throws {
         let item = try generateItem(fromMarkdown: """
         ---
         description: A description

--- a/Tests/PublishTests/Tests/MarkdownTests.swift
+++ b/Tests/PublishTests/Tests/MarkdownTests.swift
@@ -26,6 +26,17 @@ final class MarkdownTests: PublishTestCase {
         XCTAssertEqual(item.title, "Overridden title")
     }
 
+	func testParsingFileWithNoTitle() throws {
+        let item = try generateItem(fromMarkdown: """
+        ---
+        description: A description
+        ---
+        No title here
+        """, fileName: "fallback.md")
+
+        XCTAssertEqual(item.title, "fallback")
+    }
+
     func testParsingFileWithOverriddenPath() throws {
         let item = try generateItem(fromMarkdown: """
         ---
@@ -145,6 +156,7 @@ extension MarkdownTests {
         [
             ("testParsingFileWithTitle", testParsingFileWithTitle),
             ("testParsingFileWithOverriddenTitle", testParsingFileWithOverriddenTitle),
+            ("testParsingFileWithNoTitle", testParsingFileWithNoTitle),
             ("testParsingFileWithOverriddenPath", testParsingFileWithOverriddenPath),
             ("testParsingFileWithBuiltInMetadata", testParsingFileWithBuiltInMetadata),
             ("testParsingFileWithCustomMetadata", testParsingFileWithCustomMetadata),


### PR DESCRIPTION
Tiny tiny 1 line PR to use `file.nameExcludingExtension` as a fallback for `Content.title` if:

- There is no `title` in the Markdown metadata
- There is no implicit `h1` title in the file.

## Background

Unnecessary background: I'm using Publish to assemble a single page from one main index and a subfolder of things which get added to the main page. Imagine something like:

```
📂 Content/product/ ▼
    📝 index.md
    📂 features/ ▼
        📝 00-Speed.md
        📝 01-Flexibility.md
        📝 02-Power.md
```

And within my custom Theme, I'd like to do something like:

```swift
.body(
    .h1("Features"),
    .forEach(
        section.items.sorted{ $0.content.title < $1.content.title }
    ) { item in
        Node.contentBody(item.content.body)
    },
    // ...
)

```

I'm using filenames to order the items, which is handy when browsing the files. I explicitly don't want to add those titles into the metadata or h1 of the Feature markdown files, because those titles could easily get out of sync with the filename if I decide to reorder the features.

## Alternatives

As an alternative, `originalFilename: String?` or `file: File?` could be added as an optional property to `Content` or `Item`, but that doesn't feel as clean.