### PR TITLE
Add additional options for Location title generation

### DIFF
--- a/Sources/Publish/API/HTMLTitleStyle.swift
+++ b/Sources/Publish/API/HTMLTitleStyle.swift
@@ -1,0 +1,44 @@
+//
+//  HTMLTitleStyle.swift
+//  
+//
+//  Created by Ben Syverson on 2020/01/28.
+//
+
+import Foundation
+import Plot
+
+/// Enum defining the method used to generate HTML title
+public enum HTMLTitleStyle {
+    /// Use `Location.title` on its own (e.g.
+    /// `<title>About Us</title>`)
+    case locationTitle
+
+    /// Use `Location.title` and `Site.name` separated
+    /// by a supplied string (e.g.
+    /// `<title>About Us | Swifters</title>`)
+    case titleAndSiteName(separator: String)
+
+    /// Use a custom fixed string
+    case fixed(string: String)
+}
+
+/// Return the resolved title for a `Location` in a `Website` using
+/// the chosen title style
+/// - Parameter location: The location to title
+/// - Parameter site: The location's site
+internal extension HTMLTitleStyle {
+    func title<T: Website>(for location: Location, in site: T) -> String {
+        switch self {
+           case .fixed(string: let fixed):
+               return fixed
+           case .locationTitle:
+               return location.title
+            case .titleAndSiteName(separator: let separator):
+                guard !location.title.isEmpty else {
+                    return site.name
+                }
+                return location.title.appending(separator + site.name)
+        }
+    }
+}

--- a/Sources/Publish/API/PlotComponents.swift
+++ b/Sources/Publish/API/PlotComponents.swift
@@ -25,18 +25,12 @@ public extension Node where Context == HTML.DocumentContext {
     static func head<T: Website>(
         for location: Location,
         on site: T,
-        titleSeparator: String = " | ",
+        titleStyle: HTMLTitleStyle = .titleAndSiteName(separator: " | "),
         stylesheetPaths: [Path] = ["/styles.css"],
         rssFeedPath: Path? = .defaultForRSSFeed,
         rssFeedTitle: String? = nil
     ) -> Node {
-        var title = location.title
-
-        if title.isEmpty {
-            title = site.name
-        } else {
-            title.append(titleSeparator + site.name)
-        }
+        let title = titleStyle.title(for: location, in: site)
 
         var description = location.description
 

--- a/Tests/PublishTests/Tests/PlotComponentTests.swift
+++ b/Tests/PublishTests/Tests/PlotComponentTests.swift
@@ -35,6 +35,45 @@ final class PlotComponentTests: PublishTestCase {
         }
     }
 
+    func testTitleStyleDefault() {
+        let html = Node.head(
+            for: Page(path: "path", content: Content(title: "A Title")),
+            on: WebsiteStub.WithoutItemMetadata()
+        ).render()
+
+        XCTAssertTrue(html.contains(#"<title>A Title | WebsiteName</title>"#))
+    }
+
+    func testTitleStyleLocationTitle() {
+        let html = Node.head(
+            for: Page(path: "path", content: Content(title: "A Title")),
+            on: WebsiteStub.WithoutItemMetadata(),
+            titleStyle: .locationTitle
+        ).render()
+
+        XCTAssertTrue(html.contains(#"<title>A Title</title>"#))
+    }
+
+    func testTitleStyleFixed() {
+        let html = Node.head(
+            for: Page(path: "path", content: Content(title: "A Title")),
+            on: WebsiteStub.WithoutItemMetadata(),
+            titleStyle: .fixed(string: "Custom")
+        ).render()
+
+        XCTAssertTrue(html.contains(#"<title>Custom</title>"#))
+    }
+
+    func testTitleStyleSeparator() {
+        let html = Node.head(
+            for: Page(path: "path", content: Content(title: "A Title")),
+            on: WebsiteStub.WithoutItemMetadata(),
+            titleStyle: .titleAndSiteName(separator: " • ")
+        ).render()
+
+        XCTAssertTrue(html.contains(#"<title>A Title • WebsiteName</title>"#))
+    }
+
     func testRenderingAudioPlayer() throws {
         let url = try require(URL(string: "https://audio.mp3"))
         let audio = Audio(url: url, format: .mp3)
@@ -86,6 +125,10 @@ extension PlotComponentTests {
     static var allTests: Linux.TestList<PlotComponentTests> {
         [
             ("testStylesheetPaths", testStylesheetPaths),
+            ("testTitleStyleDefault", testTitleStyleDefault),
+            ("testTitleStyleLocationTitle", testTitleStyleLocationTitle),
+            ("testTitleStyleFixed", testTitleStyleFixed),
+            ("testTitleStyleSeparator", testTitleStyleSeparator),
             ("testRenderingAudioPlayer", testRenderingAudioPlayer),
             ("testRenderingHostedVideoPlayer", testRenderingHostedVideoPlayer),
             ("testRenderingYouTubeVideoPlayer", testRenderingYouTubeVideoPlayer),


### PR DESCRIPTION
## Summary

This PR offers a few new ways to specify titles for HTML pages.

## Discussion

Currently, there's a `titleSeparator` property in the `head` method exposed by Publish for use in the Plot DSL:

```swift
HTML(
    .head(for: index, on: context.site, titleSeparator: " : "),
)
```

The format of the title is fixed: you'll get `Location.title` and `Site.name` separated by a separator (`About Us | Website`).

This PR changes the API of that `head` method to expose a `titleStyle` property which takes an enum:

```swift
public enum HTMLTitleStyle {
    case locationTitle
    case titleAndSiteName(separator: String)
    case fixed(string: String)
}
```

The default remains the same—if you haven't specified `titleSeparator` in your head method, it will continue to output `Location | Site`. However, with this PR you have some flexibility:

- `locationTitle` will output just the Location's title: 

```html
<title>About Us</title>
```

- `titleAndSiteName(separator: String)` is the existing default:

```html
<title>About Us | Website</title>
```

- `fixed(string: String)` lets you override the title in the template:

```html
`<title>Template override</title>
```

The updated API can be used as such:

```swift
HTML(
    .head(for: index, on: context.site, titleStyle: .fixed("Introducing LazerPow")),
)
```

## Implications

Because this PR changes the API for the `head` method, it can/will break existing Publish projects. I think there's a way to supply the updated API to Xcode's "fixit" functionality, but I haven't had time to research that just yet.

On the positive side, the enum makes it easy to add new title generation techniques in the future. There are some other ways of addressing the same underlying need, but this seems like a good compromise of simplicity vs expressivity.

Thanks for reading!