### PR TITLE
Swift package update

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/johnsundell/ink.git",
         "state": {
           "branch": null,
-          "revision": "a9a1a0190aaacc9058a2bfbdcd831785eac26f43",
-          "version": "0.3.0"
+          "revision": "878fd897945500be1885f2c88f81f8f909224796",
+          "version": "0.4.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/johnsundell/plot.git",
         "state": {
           "branch": null,
-          "revision": "ccabb2674ca0d9ccfabd5e7c0c44c6cca6c827fb",
-          "version": "0.5.0"
+          "revision": "6dcfc1f246eabf6ea470202244115f73b75c72c4",
+          "version": "0.6.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/johnsundell/sweep.git",
         "state": {
           "branch": null,
-          "revision": "d357d12c9558e51f037bf2f956d5cf6c73dc0d44",
-          "version": "0.3.0"
+          "revision": "801c2878e4c6c5baf32fe132e1f3f3af6f9fd1b0",
+          "version": "0.4.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/johnsundell/files.git", from: "4.0.0"),
         .package(url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
         .package(url: "https://github.com/johnsundell/shellout.git", from: "2.3.0"),
-        .package(url: "https://github.com/johnsundell/sweep.git", from: "0.3.0")
+        .package(url: "https://github.com/johnsundell/sweep.git", from: "0.4.0")
     ],
     targets: [
         .target(

--- a/Tests/PublishTests/Tests/RSSFeedGenerationTests.swift
+++ b/Tests/PublishTests/Tests/RSSFeedGenerationTests.swift
@@ -33,7 +33,7 @@ final class RSSFeedGenerationTests: PublishTestCase {
         ])
 
         let feed = try folder.file(at: "Output/feed.rss").readAsString()
-        let substring = feed.substrings(between: "BEGIN ", and: " END").first
+        let substring = feed.firstSubstring(between: "BEGIN ", and: " END")
 
         XCTAssertEqual(substring, """
         <a href="https://swiftbysundell.com/page">Link</a> \


### PR DESCRIPTION
Update Publish’s dependencies to their latest versions:

- Ink `0.4.0`
- Plot `0.6.0`
- Sweep `0.4.0`

Also use Sweep’s new `firstSubstring` API.