### PR TITLE
Add Output to .gitignore

### DIFF
--- a/Sources/PublishCLICore/ProjectGenerator.swift
+++ b/Sources/PublishCLICore/ProjectGenerator.swift
@@ -47,6 +47,7 @@ private extension ProjectGenerator {
         /build
         /.build
         /.swiftpm
+        /Output
         /*.xcodeproj
         .publish
         """)


### PR DESCRIPTION
Hi!

I've just starting using Publish for a new project.

One of the first things I did was adding `Output` to the `.gitignore` since I don't really want generated content to hang out in the repository.

What do you think?

(as a next step, I realized that root folder names were a little all over the place using `String`, would it be worth moving all of those in a dedicated `enum` maybe?)