### PR TITLE
Add why Output is not part of .gitignore

### DIFF
--- a/Sources/PublishCLICore/ProjectGenerator.swift
+++ b/Sources/PublishCLICore/ProjectGenerator.swift
@@ -49,6 +49,12 @@ private extension ProjectGenerator {
         /.swiftpm
         /*.xcodeproj
         .publish
+
+        # We recommend against adding the Output directory to your .gitignore:
+        # - Pros: `git diff` will help you see how your site changed overtime;
+        # - Cons: bigger commits or pull requests, probably hard to review.
+        # You should judge for yourself.
+        # /Output
         """)
     }
 


### PR DESCRIPTION
As a follow-up to [this PR](https://github.com/JohnSundell/Publish/pull/72), and heavily influenced by the `CocoaPods` section of [the Swift `.gitignore`](https://github.com/github/gitignore/blob/master/Swift.gitignore#L51), I feel like the judgement of people having used the platform for a while (ie John Sundell) is very valuable for new-comers (ie me) hence worth mentioning explicitly. 😉