### PR TITLE
Added GitHubPages DeploymentMethod

### DIFF
--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -57,8 +57,16 @@ public extension DeploymentMethod {
                     to: .gitPull(remote: "origin", branch: branch),
                     at: folder.path
                 )
-
-                try folder.empty()
+                
+                folder.includingHidden = true
+                
+                let gitFolder = try folder.subfolder(named: ".git")
+                var subfolders = try folder.subfolders.filter { (folder) -> Bool in
+                    folder != gitFolder
+                }
+                
+                try subfolders.delete()
+                try folder.files.delete()
             }
 
             let dateFormatter = DateFormatter()

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -58,15 +58,15 @@ public extension DeploymentMethod {
                     at: folder.path
                 )
                 
-                folder.includingHidden = true
-                
                 let gitFolder = try folder.subfolder(named: ".git")
-                var subfolders = try folder.subfolders.filter { (folder) -> Bool in
-                    folder != gitFolder
-                }
                 
-                try subfolders.delete()
-                try folder.files.delete()
+                let subfolders = folder.subfolders.includingHidden
+                try subfolders.forEach { folder in
+                    if folder != gitFolder {
+                        try folder.delete()
+                    }
+                }
+                try folder.files.includingHidden.delete()
             }
 
             let dateFormatter = DateFormatter()

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -145,16 +145,17 @@ public extension DeploymentMethod {
             case .ghPages : ghPagesModeName = "gh-pages branch"
             }
             
-            let settingsURL = "\(gitHubRemote(repository: repository, useSSH: false))/settings"
+            let settingsURL = "\(gitHubRemote(repository: repository, useSSH: false, useStandardRepoURL: false))/settings"
             
             CommandLine.output("Remember to set your GitHub Pages source to \"\(ghPagesModeName)\" at \(settingsURL)",
                 as: .info)
         }
     }
     
-    private static func gitHubRemote(repository:String, useSSH: Bool) -> String {
+    private static func gitHubRemote(repository: String, useSSH: Bool, useStandardRepoURL: Bool = true) -> String {
         let prefix = useSSH ? "git@github.com:" : "https://github.com/"
-        return "\(prefix)\(repository).git"
+        let suffix = useStandardRepoURL ? ".git" : ""
+        return "\(prefix)\(repository)\(suffix)"
     }
     
     enum GitHubPagesDeploymentMode {

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -100,7 +100,7 @@ public extension DeploymentMethod {
     {
         let remote = gitHubRemote(repository: repository, useSSH: useSSH)
         
-        return DeploymentMethod(name: "GitHub Pages (\(remote)") { context in
+        return DeploymentMethod(name: "GitHub Pages (\(remote))") { context in
             let jekyllDisablingFile = try context.createOutputFile(at: Path(".nojekyll"))
             
             let branchName : String

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -36,7 +36,7 @@ public struct DeploymentMethod<Site: Website> {
 public extension DeploymentMethod {
     /// Deploy a website to a given remote using Git.
     /// - parameter remote: The full address of the remote to deploy to.
-    static func git(_ remote: String) -> Self {
+    static func git(_ remote: String, branch: String = "master") -> Self {
         DeploymentMethod(name: "Git (\(remote))") { context in
             let folder = try context.createDeploymentFolder(withPrefix: "Git") { folder in
                 if !folder.containsSubfolder(named: ".git") {
@@ -54,7 +54,7 @@ public extension DeploymentMethod {
                 )
 
                 _ = try? shellOut(
-                    to: .gitPull(remote: "origin", branch: "master"),
+                    to: .gitPull(remote: "origin", branch: branch),
                     at: folder.path
                 )
 
@@ -74,7 +74,7 @@ public extension DeploymentMethod {
                 )
 
                 try shellOut(
-                    to: .gitPush(remote: "origin", branch: "master"),
+                    to: .gitPush(remote: "origin", branch: branch),
                     at: folder.path
                 )
             } catch let error as ShellOutError {
@@ -88,8 +88,8 @@ public extension DeploymentMethod {
     /// Deploy a website to a given GitHub repository.
     /// - parameter repository: The full name of the repository (including its username).
     /// - parameter useSSH: Whether an SSH connection should be used (preferred).
-    static func gitHub(_ repository: String, useSSH: Bool = true) -> Self {
+    static func gitHub(_ repository: String, branch: String = "master", useSSH: Bool = true) -> Self {
         let prefix = useSSH ? "git@github.com:" : "https://github.com/"
-        return git("\(prefix)\(repository).git")
+        return git("\(prefix)\(repository).git", branch: branch)
     }
 }

--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -159,7 +159,7 @@ public extension PublishingContext {
 
         do {
             try folders.output.subfolders.forEach { try $0.copy(to: folder) }
-            try folders.output.files.forEach { try $0.copy(to: folder) }
+            try folders.output.files.includingHidden.forEach { try $0.copy(to: folder) }
             return folder
         } catch {
             throw FileIOError(path: path, reason: .folderCreationFailed)

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -81,6 +81,63 @@ final class DeploymentTests: PublishTestCase {
         XCTAssertFalse(try indexFile.readAsString().isEmpty)
     }
 
+    func testGitDeploymentMethodWithAnotherBranch() throws {
+        let container = try Folder.createTemporary()
+        let remote = try container.createSubfolder(named: "Remote.git")
+        let repo = try container.createSubfolder(named: "Repo")
+
+        try shellOut(to: [
+            "git init",
+            "git config --local receive.denyCurrentBranch updateInstead"
+        ], at: remote.path)
+
+        // First generate
+        try publishWebsite(in: repo, using: [
+            .generateHTML(withTheme: .foundation)
+        ])
+
+        // Then deploy
+        CommandLine.arguments.append("--deploy")
+
+        try publishWebsite(in: repo, using: [
+            .deploy(using: .git(remote.path, branch: "develop"))
+        ])
+
+        try shellOut(to: .gitCheckout(branch: "develop"), at: remote.path)
+        let indexFile = try remote.file(named: "index.html")
+        XCTAssertFalse(try indexFile.readAsString().isEmpty)
+    }
+
+    func testGitDeploymentMethodInSubfolder() throws {
+        let container = try Folder.createTemporary()
+        let remote = try container.createSubfolder(named: "Remote.git")
+        let repo = try container.createSubfolder(named: "Repo")
+
+        try shellOut(to: [
+            "git init",
+            "git config --local receive.denyCurrentBranch updateInstead",
+            "echo words > existingFile.txt"
+        ], at: remote.path)
+
+        // First generate
+        try publishWebsite(in: repo, using: [
+            .generateHTML(withTheme: .foundation)
+        ])
+
+        // Then deploy
+        CommandLine.arguments.append("--deploy")
+
+        try publishWebsite(in: repo, using: [
+            .deploy(using: .git(remote.path, targetFolderPath: Path("docs/content")))
+        ])
+
+        let indexFile = try remote.subfolder(at: "docs").subfolder(at: "content").file(named: "index.html")
+        XCTAssertFalse(try indexFile.readAsString().isEmpty)
+
+        let existingFile = try remote.file(named: "existingFile.txt")
+        XCTAssertFalse(try existingFile.readAsString().isEmpty)
+    }
+
 	func testGitDeploymentMethodWithError() throws {
         let container = try Folder.createTemporary()
         let remote = try container.createSubfolder(named: "Remote.git")
@@ -122,6 +179,8 @@ extension DeploymentTests {
             ("testDeploymentSkippedByDefault", testDeploymentSkippedByDefault),
             ("testGenerationStepsAndPluginsSkippedWhenDeploying", testGenerationStepsAndPluginsSkippedWhenDeploying),
             ("testGitDeploymentMethod", testGitDeploymentMethod),
+            ("testGitDeploymentMethodWithAnotherBranch", testGitDeploymentMethodWithAnotherBranch),
+            ("testGitDeploymentMethodInSubfolder", testGitDeploymentMethodInSubfolder),
             ("testGitDeploymentMethodWithError",testGitDeploymentMethodWithError)
         ]
     }


### PR DESCRIPTION
Added a DeploymentMethod that publishes to GitHub with an extra dotfile that enables using Publish for GitHub Pages.
This also enables setting specific branches for Git and GitHub deployments