### PR TITLE
Add ability to remove items from a section

### DIFF
--- a/Sources/Publish/API/PublishingStep.swift
+++ b/Sources/Publish/API/PublishingStep.swift
@@ -134,6 +134,26 @@ public extension PublishingStep {
             try MarkdownFileHandler().addMarkdownFiles(in: folder, to: &context)
         }
     }
+    
+    /// Remove all items matching a predicate, optionally within a specific section.
+    /// - parameter section: Any specific section to remove all items within.
+    /// - parameter predicate: Any predicate to filter the items using.
+    static func removeAllItems(
+        in section: Site.SectionID? = nil,
+        matching predicate: Predicate<Item<Site>> = .any
+    ) -> Self {
+        let nameSuffix = section.map { " in '\($0)'" } ?? ""
+
+        return step(named: "Remove items" + nameSuffix) { context in
+            if let section = section {
+                context.sections[section].removeItems(matching: predicate)
+            } else {
+                for section in context.sections.ids {
+                    context.sections[section].removeItems(matching: predicate)
+                }
+            }
+        }
+    }
 
     /// Mutate all items matching a predicate, optionally within a specific section.
     /// - parameter section: Any specific section to mutate all items within.

--- a/Sources/Publish/API/Section.swift
+++ b/Sources/Publish/API/Section.swift
@@ -98,9 +98,7 @@ public extension Section {
     /// Remove all items within this section matching a given predicate.
     /// - Parameter predicate: Any predicate to filter the items based on.
     mutating func removeItems(matching predicate: Predicate<Item<Site>> = .any) {
-        items = items.filter { item -> Bool in
-            return !predicate.matches(item)
-        }
+        items.removeAll(where: predicate.matches)
     }
 
     /// Sort all items within this section using a closure.

--- a/Sources/Publish/API/Section.swift
+++ b/Sources/Publish/API/Section.swift
@@ -94,6 +94,14 @@ public extension Section {
             return item
         }
     }
+    
+    /// Remove all items within this section matching a given predicate.
+    /// - Parameter predicate: Any predicate to filter the items based on.
+    mutating func removeItems(matching predicate: Predicate<Item<Site>> = .any) {
+        items = items.filter { item -> Bool in
+            return !predicate.matches(item)
+        }
+    }
 
     /// Sort all items within this section using a closure.
     /// - Parameter sorter: The closure to use to sort the items.

--- a/Sources/Publish/API/Section.swift
+++ b/Sources/Publish/API/Section.swift
@@ -99,22 +99,14 @@ public extension Section {
     /// - Parameter predicate: Any predicate to filter the items based on.
     mutating func removeItems(matching predicate: Predicate<Item<Site>> = .any) {
         items.removeAll(where: predicate.matches)
+        rebuildIndexes()
     }
 
     /// Sort all items within this section using a closure.
     /// - Parameter sorter: The closure to use to sort the items.
     mutating func sortItems(by sorter: (Item<Site>, Item<Site>) throws -> Bool) rethrows {
         try items.sort(by: sorter)
-        itemIndexesByPath = [:]
-        itemIndexesByTag = [:]
-
-        for (index, item) in items.enumerated() {
-            itemIndexesByPath[item.relativePath] = index
-
-            for tag in item.tags {
-                itemIndexesByTag[tag, default: []].insert(index)
-            }
-        }
+        rebuildIndexes()
     }
 }
 
@@ -174,5 +166,18 @@ private extension Section {
         }
 
         lastItemModificationDate = newDate
+    }
+    
+    mutating func rebuildIndexes() {
+        itemIndexesByPath = [:]
+        itemIndexesByTag = [:]
+
+        for (index, item) in items.enumerated() {
+            itemIndexesByPath[item.relativePath] = index
+
+            for tag in item.tags {
+                itemIndexesByTag[tag, default: []].insert(index)
+            }
+        }
     }
 }

--- a/Tests/PublishTests/Tests/ContentMutationTests.swift
+++ b/Tests/PublishTests/Tests/ContentMutationTests.swift
@@ -105,6 +105,20 @@ final class ContentMutationTests: PublishTestCase {
 
         XCTAssertEqual(Array(site.sections[.one].items), items)
     }
+    
+    func testRemovingItemsMatchingPredicate() throws {
+        let items = [
+            Item.stub(withPath: "a").setting(\.tags, to: ["one"]),
+            Item.stub(withPath: "b").setting(\.tags, to: ["one", "two"])
+        ]
+
+        let site = try publishWebsite(using: [
+            .addItems(in: items),
+            .removeAllItems(matching: \.tags ~= "two")
+        ])
+
+        XCTAssertNotEqual(Array(site.sections[.one].items), items)
+    }
 
     func testMutatingItemsByChangingTags() throws {
         var items = [

--- a/Tests/PublishTests/Tests/ContentMutationTests.swift
+++ b/Tests/PublishTests/Tests/ContentMutationTests.swift
@@ -44,6 +44,8 @@ final class ContentMutationTests: PublishTestCase {
         ])
 
         XCTAssertNotEqual(Array(site.sections[.one].items), items)
+        // Make sure item indexes are updated
+        XCTAssertNil(site.sections[.one].item(at: "b"))
     }
 
     func testMutatingAllSections() throws {

--- a/Tests/PublishTests/Tests/ContentMutationTests.swift
+++ b/Tests/PublishTests/Tests/ContentMutationTests.swift
@@ -32,6 +32,20 @@ final class ContentMutationTests: PublishTestCase {
         XCTAssertEqual(site.sections[.one].items.first?.body.html, "<div>Plot!</div>")
     }
 
+    func testRemovingItemsMatchingPredicate() throws {
+        let items = [
+            Item.stub(withPath: "a").setting(\.tags, to: ["one"]),
+            Item.stub(withPath: "b").setting(\.tags, to: ["one", "two"])
+        ]
+
+        let site = try publishWebsite(using: [
+            .addItems(in: items),
+            .removeAllItems(matching: \.tags ~= "two")
+        ])
+
+        XCTAssertNotEqual(Array(site.sections[.one].items), items)
+    }
+
     func testMutatingAllSections() throws {
         let site = try publishWebsite(using: [
             .step(named: "Set section titles") { context in
@@ -104,20 +118,6 @@ final class ContentMutationTests: PublishTestCase {
         items[1].title = "One Two"
 
         XCTAssertEqual(Array(site.sections[.one].items), items)
-    }
-    
-    func testRemovingItemsMatchingPredicate() throws {
-        let items = [
-            Item.stub(withPath: "a").setting(\.tags, to: ["one"]),
-            Item.stub(withPath: "b").setting(\.tags, to: ["one", "two"])
-        ]
-
-        let site = try publishWebsite(using: [
-            .addItems(in: items),
-            .removeAllItems(matching: \.tags ~= "two")
-        ])
-
-        XCTAssertNotEqual(Array(site.sections[.one].items), items)
     }
 
     func testMutatingItemsByChangingTags() throws {
@@ -294,6 +294,7 @@ extension ContentMutationTests {
         [
             ("testAddingItemUsingClosureAPI", testAddingItemUsingClosureAPI),
             ("testAddingItemUsingPlotHierarchy", testAddingItemUsingPlotHierarchy),
+            ("testRemovingItemsMatchingPredicate", testRemovingItemsMatchingPredicate),
             ("testMutatingAllSections", testMutatingAllSections),
             ("testMutatingAllItems", testMutatingAllItems),
             ("testMutatingItemsInSection", testMutatingItemsInSection),

--- a/Tests/PublishTests/Tests/ContentMutationTests.swift
+++ b/Tests/PublishTests/Tests/ContentMutationTests.swift
@@ -43,9 +43,8 @@ final class ContentMutationTests: PublishTestCase {
             .removeAllItems(matching: \.tags ~= "two")
         ])
 
-        XCTAssertNotEqual(Array(site.sections[.one].items), items)
-        // Make sure item indexes are updated
-        XCTAssertNil(site.sections[.one].item(at: "b"))
+        XCTAssertEqual(site.sections[.one].items, [items[0]])
+        XCTAssertNil(site.sections[.one].item(at: "b"), "Item indexes not updated")
     }
 
     func testMutatingAllSections() throws {


### PR DESCRIPTION
This change adds a `PublishingStep` that makes it possible to conditionally remove items.

## Background

Coming from other static site generators, I have grown accustomed to writing posts labeled as drafts, which will be excluded from a build until marked as ready. This PR is meant to provide the capability to create such a workflow.

I use this feature for my site by adding an optional `draft: Bool?` item metadata property, and then conditionally run a step that removes such items from the build:

```swift
.if(CommandLine.arguments.contains("--removeDrafts"), .removeAllItems(matching: \.metadata.draft == true))
```

I then finish things off by passing a `--removeDrafts` flag when deploying my site.