### PR TITLE
Don’t force section on addItem

### DIFF
--- a/Sources/Publish/API/Section.swift
+++ b/Sources/Publish/API/Section.swift
@@ -58,8 +58,8 @@ public extension Section {
         configure: (inout Item<Site>) throws -> Void
     ) rethrows {
         var item = Item<Site>(path: path, sectionID: id, metadata: metadata)
-        try configure(&item)
         item.sectionID = id
+        try configure(&item)
         addItem(item)
     }
 


### PR DESCRIPTION
This allows the configure closure to set an entire new item, including changing it’s section.

I guess the big question is, is there a reason to force the section? 

The scenario for this is the following: In my website I have a section for all the articles of the blog and I want to have another section that displays only specific articles based on some criteria. This doesn't seem straightforward so what I'm doing is the following:

1. Add a section case in the enum.
2. Make an empty folder so Publish doesn't error. (the folder doesn't need any md, we will add them with a step)
3. Make a step that adds the items to the section:

```
            let items = context.items...
            for item in items {
                context.sections[.section].addItem(
                    at: item.path,
                    withMetadata: item.metadata
                ) { newItem in
                    newItem = item
                }
            }
```

Without this patch the `path` of the new items will be pointing to the new section we're creating, but what I really want is that their path points to their original location. 

Is there a better approach to build something like this?