### PR TITLE
ISO8601DateFormatter

### DIFF
--- a/Sources/Publish/API/AnyDateFormatter.swift
+++ b/Sources/Publish/API/AnyDateFormatter.swift
@@ -1,0 +1,28 @@
+//
+//  AnyDateFormatter.swift
+//  
+//
+//  Created by Dustin Pfannenstiel on 3/10/20.
+//  Copyright (c) Dustin Pfannenstiel, 2020
+//  MIT license, see LICENSE file for details
+//
+
+import Foundation
+
+public protocol AnyDateFormatter: Formatter {
+    var timeZone: TimeZone! { get set }
+    var dateFormat: String! { get set }
+
+    func date(from string: String) -> Date?
+    func string(from date: Date) -> String
+}
+
+extension DateFormatter: AnyDateFormatter {}
+
+@available(OSX 10.12, *)
+extension ISO8601DateFormatter: AnyDateFormatter {
+    public var dateFormat: String! {
+        get { "ISO8601DateFormatter" }
+        set { print("Warning: May not set dateFormat for ISO8601DateFormatter") }
+    }
+}

--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -22,7 +22,7 @@ public struct PublishingContext<Site: Website> {
     public var markdownParser = MarkdownParser()
     /// The date formatter that this publishing session is using when parsing
     /// dates from Markdown files.
-    public var dateFormatter: DateFormatter
+    public var dateFormatter: AnyDateFormatter
     /// A representation of the website's main index page.
     public var index = Index()
     /// The sections that the website contains.

--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -45,9 +45,15 @@ public struct PublishingContext<Site: Website> {
         self.folders = folders
         self.stepName = firstStepName
 
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
-        dateFormatter.timeZone = .current
+
+        let dateFormatter: AnyDateFormatter
+        if #available(OSX 10.12, *) {
+            dateFormatter = ISO8601DateFormatter()
+        } else {
+            dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
+            dateFormatter.timeZone = .current
+        }
         self.dateFormatter = dateFormatter
     }
 }

--- a/Sources/Publish/Internal/MarkdownContentFactory.swift
+++ b/Sources/Publish/Internal/MarkdownContentFactory.swift
@@ -11,7 +11,7 @@ import Codextended
 
 internal struct MarkdownContentFactory<Site: Website> {
     let parser: MarkdownParser
-    let dateFormatter: DateFormatter
+    let dateFormatter: AnyDateFormatter
 
     func makeContent(fromFile file: File) throws -> Content {
         let markdown = try parser.parse(file.readAsString())

--- a/Sources/Publish/Internal/MarkdownMetadataDecoder.swift
+++ b/Sources/Publish/Internal/MarkdownMetadataDecoder.swift
@@ -11,12 +11,12 @@ internal final class MarkdownMetadataDecoder: Decoder {
     let codingPath: [CodingKey]
 
     private let metadata: [String : String]
-    private let dateFormatter: DateFormatter
+    private let dateFormatter: AnyDateFormatter
     private lazy var keyedContainers = [ObjectIdentifier : Any]()
 
     init(metadata: [String : String],
          codingPath: [CodingKey] = [],
-         dateFormatter: DateFormatter) {
+         dateFormatter: AnyDateFormatter) {
         self.metadata = metadata
         self.codingPath = codingPath
         self.dateFormatter = dateFormatter
@@ -73,11 +73,11 @@ private extension MarkdownMetadataDecoder {
         let keys: KeyMap<Key>
         let codingPath: [CodingKey]
         let prefix: String
-        let dateFormatter: DateFormatter
+        let dateFormatter: AnyDateFormatter
 
         init(metadata: [String : String],
              codingPath: [CodingKey],
-             dateFormatter: DateFormatter) {
+             dateFormatter: AnyDateFormatter) {
             self.metadata = metadata
             self.keys = KeyMap(raw: metadata.keys, codingPath: codingPath)
             self.codingPath = codingPath
@@ -622,7 +622,7 @@ private extension Date {
     static func decode(from string: String,
                        forKey key: CodingKey?,
                        at codingPath: [CodingKey],
-                       formatter: DateFormatter) throws -> Self {
+                       formatter: AnyDateFormatter) throws -> Self {
         guard let date = formatter.date(from: string) else {
             let formatDescription = formatter.dateFormat.map {
                 " Expected format: \($0)."


### PR DESCRIPTION
As a web site developer I want to support time zone within my posts without having to write a custom date formatter. The default date formatter has support for the format "yyyy-MM-dd HH:mm", which ignores time zone.  

In Publish 0.5.0 date formatting is handled via the `DateFormatter` class, which conforms to the `Formatter` protocol.  Along with the many fine date formats there exists ISO 8601, which the Foundation framework implements in the `ISO8601DateFormatter` class, which also conforms to the `Formatter` protocol.  Since `PublishingContext` requires a `DateFormatter` I cannot use `ISO8601DateFormatter`.

This pull request makes two changes.

First, it introduces `AnyDateFormatter`, a minimal protocol to define a common interface for date formatters to conform.  Most of the API is already implemented by `DateFormatter` and  `ISO8601DateFormatter`, so implementing the protocol as an extension is trivial.

Second, `PublishingContext` changes  `dateFormatter` to a `AnyDateFormatter` and then make any subsequent changes to support that type change.  As part of this change, the default `dateFormatter` value is set to a `ISO8601DateFormatter`.  This will result in a breaking change for existing users of Publish, but it is believed that using a well known date format represents a common initial case.