### PR TITLE
RSS: Enable filtering of items using a predicate

### DIFF
--- a/Sources/Publish/API/Predicate.swift
+++ b/Sources/Publish/API/Predicate.swift
@@ -22,6 +22,12 @@ public struct Predicate<Target> {
 public extension Predicate {
     /// Create a predicate that matches any candidate.
     static var any: Self { Predicate { _ in true } }
+
+    /// Create an inverse of this predicate - that is one that matches
+    /// all candidates that this predicate does not, and vice versa.
+    func inverse() -> Self {
+        Predicate { !self.matches($0) }
+    }
 }
 
 /// Create a predicate for comparing a key path against a value.

--- a/Sources/Publish/API/PublishingStep.swift
+++ b/Sources/Publish/API/PublishingStep.swift
@@ -330,11 +330,14 @@ public extension PublishingStep {
     /// Generate an RSS feed for the website.
     /// - parameter includedSectionIDs: The IDs of the sections which items
     ///   to include when generating the feed.
+    /// - parameter itemPredicate: A predicate used to determine whether to
+    ///   include a given item within the generated feed (default: include all).
     /// - parameter config: The configuration to use when generating the feed.
     /// - parameter date: The date that should act as the build and publishing
     ///   date for the generated feed (default: the current date).
     static func generateRSSFeed(
         including includedSectionIDs: Set<Site.SectionID>,
+        itemPredicate: Predicate<Item<Site>>? = nil,
         config: RSSFeedConfiguration = .default,
         date: Date = Date()
     ) -> Self {
@@ -343,6 +346,7 @@ public extension PublishingStep {
         return step(named: "Generate RSS feed") { context in
             let generator = RSSFeedGenerator(
                 includedSectionIDs: includedSectionIDs,
+                itemPredicate: itemPredicate,
                 config: config,
                 context: context,
                 date: date

--- a/Sources/Publish/Internal/RSSFeedGenerator.swift
+++ b/Sources/Publish/Internal/RSSFeedGenerator.swift
@@ -10,6 +10,7 @@ import Files
 
 internal struct RSSFeedGenerator<Site: Website> {
     let includedSectionIDs: Set<Site.SectionID>
+    let itemPredicate: Predicate<Item<Site>>?
     let config: RSSFeedConfiguration
     let context: PublishingContext<Site>
     let date: Date
@@ -25,6 +26,10 @@ internal struct RSSFeedGenerator<Site: Website> {
         }
 
         items.sort { $0.date > $1.date }
+
+        if let predicate = itemPredicate?.inverse() {
+            items.removeAll(where: predicate.matches)
+        }
 
         if let date = context.lastGenerationDate, let cache = oldCache {
             if cache.config == config, cache.itemCount == items.count {


### PR DESCRIPTION
This change enables users to decide whether to include a given item in a generated RSS feed using a predicate, which can be very useful when wanting to conditionally decide which items that go into a certain feed.