### PR TITLE
RSS: Add APIs for defining a prefix and suffix for an item’s body

### DIFF
--- a/Sources/Publish/API/ItemRSSProperties.swift
+++ b/Sources/Publish/API/ItemRSSProperties.swift
@@ -16,15 +16,26 @@ public struct ItemRSSProperties: Codable, Hashable {
     public var titlePrefix: String?
     /// Any suffix that should be added to the item's title within an RSS feed.
     public var titleSuffix: String?
+    /// Any prefix that should be added to the item's body HTML within an RSS feed.
+    public var bodyPrefix: String?
+    /// Any suffix that should be added to the item's body HTML within an RSS feed.
+    public var bodySuffix: String?
 
     /// Initialize an instance of this type
     /// - parameter guid: Any specific GUID that should be added for the item.
     /// - parameter titlePrefix: Any prefix that should be added to the item's title.
     /// - parameter titleSuffix: Any suffix that should be added to the item's title.
+    /// - parameter bodyPrefix: Any prefix that should be added to the item's body HTML.
+    /// - parameter bodySuffix: Any suffix that should be added to the item's body HTML.
     public init(guid: String? = nil,
                 titlePrefix: String? = nil,
-                titleSuffix: String? = nil) {
+                titleSuffix: String? = nil,
+                bodyPrefix: String? = nil,
+                bodySuffix: String? = nil) {
         self.guid = guid
         self.titlePrefix = titlePrefix
+        self.titleSuffix = titleSuffix
+        self.bodyPrefix = bodyPrefix
+        self.bodySuffix = bodySuffix
     }
 }

--- a/Sources/Publish/API/PlotComponents.swift
+++ b/Sources/Publish/API/PlotComponents.swift
@@ -157,7 +157,10 @@ internal extension Node where Context: RSSItemContext {
         let baseURL = site.url
         let prefixes = (href: "href=\"", src: "src=\"")
 
-        var html = item.body.html
+        var html = item.rssProperties.bodyPrefix ?? ""
+        html.append(item.body.html)
+        html.append(item.rssProperties.bodySuffix ?? "")
+
         var links = [(url: URL, range: ClosedRange<String.Index>, isHref: Bool)]()
 
         html.scan(using: [

--- a/Tests/PublishTests/Tests/RSSFeedGenerationTests.swift
+++ b/Tests/PublishTests/Tests/RSSFeedGenerationTests.swift
@@ -59,7 +59,7 @@ final class RSSFeedGenerationTests: PublishTestCase {
         """)
     }
 
-    func testItemPrefixAndSuffix() throws {
+    func testItemTitlePrefixAndSuffix() throws {
         let folder = try Folder.createTemporary()
 
         try generateFeed(in: folder, content: [
@@ -74,6 +74,26 @@ final class RSSFeedGenerationTests: PublishTestCase {
 
         let feed = try folder.file(at: "Output/feed.rss").readAsString()
         XCTAssertTrue(feed.contains("<title>PrefixTitleSuffix</title>"))
+    }
+
+    func testItemBodyPrefixAndSuffix() throws {
+        let folder = try Folder.createTemporary()
+
+        try generateFeed(in: folder, content: [
+            "one/item.md": """
+            ---
+            rss.bodyPrefix: Prefix
+            rss.bodySuffix: Suffix
+            ---
+            Body
+            """
+        ])
+
+        let feed = try folder.file(at: "Output/feed.rss").readAsString()
+
+        XCTAssertTrue(feed.contains("""
+        <content:encoded><![CDATA[Prefix<p>Body</p>Suffix]]></content:encoded>
+        """))
     }
 
     func testReusingPreviousFeedIfNoItemsWereModified() throws {
@@ -138,7 +158,8 @@ extension RSSFeedGenerationTests {
             ("testOnlyIncludingSpecifiedSections", testOnlyIncludingSpecifiedSections),
             ("testOnlyIncludingItemsMatchingPredicate", testOnlyIncludingItemsMatchingPredicate),
             ("testConvertingRelativeLinksToAbsolute", testConvertingRelativeLinksToAbsolute),
-            ("testItemPrefixAndSuffix", testItemPrefixAndSuffix),
+            ("testItemTitlePrefixAndSuffix", testItemTitlePrefixAndSuffix),
+            ("testItemBodyPrefixAndSuffix", testItemBodyPrefixAndSuffix),
             ("testReusingPreviousFeedIfNoItemsWereModified", testReusingPreviousFeedIfNoItemsWereModified),
             ("testNotReusingPreviousFeedIfConfigChanged", testNotReusingPreviousFeedIfConfigChanged),
             ("testNotReusingPreviousFeedIfItemWasAdded", testNotReusingPreviousFeedIfItemWasAdded)


### PR DESCRIPTION
This change makes it possible to define a prefix and/or suffix that will get added to an item’s body when rendered within an RSS feed. This can, for example, be used to provide specific intro paragraphs for RSS items, to embed media players, and so on.

Just like the equivalent APIs for titles, these prefixes/suffixes are rendered as-is and are not converted to HTML automatically.