### PR TITLE
Enhance CLI text output clarity

### DIFF
--- a/Sources/PublishCLICore/CLI.swift
+++ b/Sources/PublishCLICore/CLI.swift
@@ -55,20 +55,17 @@ private extension CLI {
     func outputHelpText() {
         print("""
         Publish Command Line Interface
-        ------------------------------
-        Interact with the Publish static site generator from
-        the command line, to create new websites, or to generate
-        and deploy existing ones.
 
-        Available commands:
+        Usage: publish <command> [options]
 
-        - new: Set up a new website in the current folder.
-        - generate: Generate the website in the current folder.
-        - run: Generate and run a localhost server on default port 8000
-               for the website in the current folder. Use the "-p"
-               or "--port" option for customizing the default port.
-        - deploy: Generate and deploy the website in the current
-               folder, according to its deployment method.
+        Commands
+          new           Set up a new website in the current directory.
+          generate      Generate the website in the current directory.
+          run           Generate and run a localhost server on port 8000 for the website in the current directory.
+          deploy        Generate and deploy the website in the current directory, according to its deployment method.
+
+        Options
+          -p --port <port>   The port on which to run the localhost server.
         """)
     }
 

--- a/Sources/PublishCLICore/CLIError.swift
+++ b/Sources/PublishCLICore/CLIError.swift
@@ -16,13 +16,13 @@ extension CLIError: CustomStringConvertible {
     var description: String {
         switch self {
         case .newProjectFolderNotEmpty:
-            return "New projects can only be generated in empty folders."
+            return "New projects can only be generated in empty directories."
         case .notASwiftPackage:
-            return "The current folder is not a Swift package."
+            return "The current directory is not a Swift package."
         case .failedToResolveSwiftPackageName:
             return "Failed to resolve the Swift package's name."
         case .outputFolderNotFound:
-            return "The website's Output folder couldn't be found."
+            return "The website's Output directory couldn't be found."
         case .failedToStartLocalhostServer(let error):
             return "Failed to start localhost server (\(error))"
         }

--- a/Sources/PublishCLICore/ProjectGenerator.swift
+++ b/Sources/PublishCLICore/ProjectGenerator.swift
@@ -34,8 +34,8 @@ internal struct ProjectGenerator {
         try generateMainFile()
 
         print("""
-        ✅ Generated website project for '\(siteName)'
-        Run 'open Package.swift' to open it and start building
+        ✅ Generated website project for '\(siteName)'.
+        Run 'open Package.swift' to open it and start building.
         """)
     }
 }


### PR DESCRIPTION
Little enhancements to the texts the CLI outputs to `stdout` :

- A cleaner and more readable *usage*.
- Changed all occurrences of *folder* to *directory*.
- Minor typo fix.