### PR TITLE
Bump Swift version to 5.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/johnsundell/plot.git",
         "state": {
           "branch": null,
-          "revision": "6dcfc1f246eabf6ea470202244115f73b75c72c4",
-          "version": "0.6.0"
+          "revision": "61e828949ca6f84071bde65c8fc046cf74b7d1a2",
+          "version": "0.8.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 
 /**
 *  Publish
@@ -15,12 +15,12 @@ let package = Package(
         .executable(name: "publish-cli", targets: ["PublishCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/johnsundell/ink.git", from: "0.2.0"),
-        .package(url: "https://github.com/johnsundell/plot.git", from: "0.4.0"),
-        .package(url: "https://github.com/johnsundell/files.git", from: "4.0.0"),
-        .package(url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
-        .package(url: "https://github.com/johnsundell/shellout.git", from: "2.3.0"),
-        .package(url: "https://github.com/johnsundell/sweep.git", from: "0.4.0")
+        .package(name: "Ink", url: "https://github.com/johnsundell/ink.git", from: "0.2.0"),
+        .package(name: "Plot", url: "https://github.com/johnsundell/plot.git", from: "0.4.0"),
+        .package(name: "Files", url: "https://github.com/johnsundell/files.git", from: "4.0.0"),
+        .package(name: "Codextended", url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
+        .package(name: "ShellOut", url: "https://github.com/johnsundell/shellout.git", from: "2.3.0"),
+        .package(name: "Sweep", url: "https://github.com/johnsundell/sweep.git", from: "0.4.0")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-    <img src="https://img.shields.io/badge/Swift-5.1-orange.svg" />
+    <img src="https://img.shields.io/badge/Swift-5.2-orange.svg" />
     <a href="https://swift.org/package-manager">
         <img src="https://img.shields.io/badge/swiftpm-compatible-brightgreen.svg?style=flat" alt="Swift Package Manager" />
     </a>
@@ -227,6 +227,12 @@ try DeliciousRecipes().publish(using: [
 *If your plugin is hosted on GitHub you can use the `publish-plugin` [topic](https://help.github.com/en/github/administering-a-repository/classifying-your-repository-with-topics#adding-topics-to-your-repository) so it can be found with the rest of [community plugins](https://github.com/topics/publish-plugin?l=swift).*
 
 For a real-world example of a Publish plugin, check out the [official Splash plugin](https://github.com/johnsundell/splashpublishplugin), which makes it really easy to integrate the [Splash syntax highlighter](https://github.com/johnsundell/splash) with Publish.
+
+## System requirements
+
+To be able to successfully use Publish, make sure that your system has Swift version 5.2 (or later) installed. If you’re using a Mac, also make sure that `xcode-select` is pointed at an Xcode installation that includes the required version of Swift, and that you’re running macOS Catalina (10.15) or later. 
+
+Please note that Publish **does not** officially support any form of beta software, including beta versions of Xcode and macOS, or unreleased versions of Swift.
 
 ## Installation
 


### PR DESCRIPTION
Swift version 5.2 (or later) is now required to use Publish.