### PR TITLE
Extend Deployment Capabilities

### DIFF
--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -57,8 +57,16 @@ public extension DeploymentMethod {
                     to: .gitPull(remote: "origin", branch: branch),
                     at: folder.path
                 )
-
-                try folder.empty()
+                
+                folder.includingHidden = true
+                
+                let gitFolder = try folder.subfolder(named: ".git")
+                var subfolders = try folder.subfolders.filter { (folder) -> Bool in
+                    folder != gitFolder
+                }
+                
+                try subfolders.delete()
+                try folder.files.delete()
             }
 
             let dateFormatter = DateFormatter()

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -58,15 +58,15 @@ public extension DeploymentMethod {
                     at: folder.path
                 )
                 
-                folder.includingHidden = true
-                
                 let gitFolder = try folder.subfolder(named: ".git")
-                var subfolders = try folder.subfolders.filter { (folder) -> Bool in
-                    folder != gitFolder
-                }
                 
-                try subfolders.delete()
-                try folder.files.delete()
+                let subfolders = folder.subfolders.includingHidden
+                try subfolders.forEach { folder in
+                    if folder != gitFolder {
+                        try folder.delete()
+                    }
+                }
+                try folder.files.includingHidden.delete()
             }
 
             let dateFormatter = DateFormatter()

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -36,9 +36,12 @@ public struct DeploymentMethod<Site: Website> {
 public extension DeploymentMethod {
     /// Deploy a website to a given remote using Git.
     /// - parameter remote: The full address of the remote to deploy to.
-    static func git(_ remote: String, branch: String = "master") -> Self {
+    /// - parameter branch: The branch to deploy to.
+    /// - parameter targetFolderPath: Any specific subfolder path to deploy the output to.
+    ///   If `nil`, then the output will replace all content in the branch.
+    static func git(_ remote: String, branch: String = "master", targetFolderPath: Path? = nil) -> Self {
         DeploymentMethod(name: "Git (\(remote))") { context in
-            let folder = try context.createDeploymentFolder(withPrefix: "Git") { folder in
+            let folder = try context.createDeploymentFolder(withPrefix: "Git", targetFolderPath: targetFolderPath) { folder in
                 try folder.empty(includingHidden: true)
 
                 try shellOut(to: .gitInit(), at: folder.path)
@@ -47,7 +50,17 @@ public extension DeploymentMethod {
 
                 try shellOut(to: "git fetch", at: folder.path)
 
-                try shellOut(to: "git symbolic-ref HEAD refs/remotes/origin/\(branch)", at: folder.path)
+                if targetFolderPath != nil {
+                    try shellOut(
+                        to: "git checkout \(branch) || git checkout -b \(branch)",
+                        at: folder.path
+                    )
+                } else {
+                    try shellOut(
+                        to: "git symbolic-ref HEAD refs/remotes/origin/\(branch)",
+                        at: folder.path
+                    )
+                }
             }
 
             let dateFormatter = DateFormatter()
@@ -62,15 +75,11 @@ public extension DeploymentMethod {
                     at: folder.path
                 )
 
-                try shellOut(
-                    to: "git checkout -b \(branch)",
-                    at: folder.path
-                )
+                if targetFolderPath == nil {
+                    try shellOut(to: "git checkout -b \(branch)", at: folder.path)
+                }
 
-                try shellOut(
-                    to: "git push origin \(branch)",
-                    at: folder.path
-                )
+                try shellOut(to: "git push origin \(branch)", at: folder.path)
             } catch let error as ShellOutError {
                 throw PublishingError(infoMessage: error.message)
             } catch {
@@ -81,14 +90,22 @@ public extension DeploymentMethod {
 
     /// Deploy a website to a given GitHub repository.
     /// - parameter repository: The full name of the repository (including its username).
+    /// - parameter branch: The branch to deploy to.
+    /// - parameter targetFolderPath: Any specific subfolder path to deploy the output to.
+    ///   If `nil`, then the output will replace all content in the branch.
     /// - parameter useSSH: Whether an SSH connection should be used (preferred).
-    static func gitHub(_ repository: String, branch: String = "master", useSSH: Bool = true) -> Self {
+    static func gitHub(_ repository: String, branch: String = "master", targetFolderPath: Path? = nil, useSSH: Bool = true) -> Self {
         git(gitHubRemote(repository: repository, useSSH: useSSH),
-            branch: branch)
+            branch: branch, targetFolderPath: targetFolderPath)
     }
-    
+
+    /// Deploy a website using GitHub Pages.
+    /// - parameter repository: The full name of the repository (including its username).
+    /// - parameter source: The publishing source for your GitHub Pages site.
+    ///   This should be set in your repository settings.
+    /// - parameter useSSH: Whether an SSH connection should be used (preferred).
     static func gitHubPages(_ repository: String,
-                            on branch: GitHubPagesDeploymentMode = .master,
+                            source: GitHubPagesDeploymentMode = .master,
                             useSSH: Bool = true)
         -> Self
     {
@@ -98,23 +115,13 @@ public extension DeploymentMethod {
             let jekyllDisablingFile = try context.createOutputFile(at: Path(".nojekyll"))
             
             let branchName : String
-            var docsModeFolders : (Folder, Folder)?
+            var targetFolderPath: Path? = nil
             
-            switch branch {
+            switch source {
             case .ghPages :
                 branchName = "gh-pages"
             case .masterDocs :
-                let docs = try context.createOutputFolder(at: Path("docs"))
-
-                guard let docsParent = docs.parent else {
-                    try jekyllDisablingFile.delete()
-                    try docs.delete()
-                    return
-                }
-                
-                try docsParent.moveContents(to: docs)
-                
-                docsModeFolders = (docs, docsParent)
+                targetFolderPath = Path("docs")
                 fallthrough
             case .master :
                 branchName = "master"
@@ -122,18 +129,14 @@ public extension DeploymentMethod {
             
             try gitHub(repository,
                        branch: branchName,
+                       targetFolderPath: targetFolderPath,
                        useSSH: useSSH)
                 .body(context)
-            
-            if let (docs, docsParent) = docsModeFolders {
-                try docs.moveContents(to: docsParent)
-                try docs.delete()
-            }
             
             try jekyllDisablingFile.delete()
             
             let ghPagesModeName : String
-            switch branch {
+            switch source {
             case .master : ghPagesModeName = "master branch"
             case .masterDocs : ghPagesModeName = "master branch /docs folder"
             case .ghPages : ghPagesModeName = "gh-pages branch"

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -145,16 +145,17 @@ public extension DeploymentMethod {
             case .ghPages : ghPagesModeName = "gh-pages branch"
             }
             
-            let settingsURL = "\(gitHubRemote(repository: repository, useSSH: false))/settings"
+            let settingsURL = "\(gitHubRemote(repository: repository, useSSH: false, useStandardRepoURL: false))/settings"
             
             CommandLine.output("Remember to set your GitHub Pages source to \"\(ghPagesModeName)\" at \(settingsURL)",
                 as: .info)
         }
     }
     
-    private static func gitHubRemote(repository:String, useSSH: Bool) -> String {
+    private static func gitHubRemote(repository: String, useSSH: Bool, useStandardRepoURL: Bool = true) -> String {
         let prefix = useSSH ? "git@github.com:" : "https://github.com/"
-        return "\(prefix)\(repository).git"
+        let suffix = useStandardRepoURL ? ".git" : ""
+        return "\(prefix)\(repository)\(suffix)"
     }
     
     enum GitHubPagesDeploymentMode {

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -95,67 +95,11 @@ public extension DeploymentMethod {
     ///   If `nil`, then the output will replace all content in the branch.
     /// - parameter useSSH: Whether an SSH connection should be used (preferred).
     static func gitHub(_ repository: String, branch: String = "master", targetFolderPath: Path? = nil, useSSH: Bool = true) -> Self {
-        git(gitHubRemote(repository: repository, useSSH: useSSH),
-            branch: branch, targetFolderPath: targetFolderPath)
-    }
-
-    /// Deploy a website using GitHub Pages.
-    /// - parameter repository: The full name of the repository (including its username).
-    /// - parameter source: The publishing source for your GitHub Pages site.
-    ///   This should be set in your repository settings.
-    /// - parameter useSSH: Whether an SSH connection should be used (preferred).
-    static func gitHubPages(_ repository: String,
-                            source: GitHubPagesDeploymentMode = .master,
-                            useSSH: Bool = true)
-        -> Self
-    {
-        let remote = gitHubRemote(repository: repository, useSSH: useSSH)
-        
-        return DeploymentMethod(name: "GitHub Pages (\(remote))") { context in
-            let jekyllDisablingFile = try context.createOutputFile(at: Path(".nojekyll"))
-            
-            let branchName : String
-            var targetFolderPath: Path? = nil
-            
-            switch source {
-            case .ghPages :
-                branchName = "gh-pages"
-            case .masterDocs :
-                targetFolderPath = Path("docs")
-                fallthrough
-            case .master :
-                branchName = "master"
-            }
-            
-            try gitHub(repository,
-                       branch: branchName,
-                       targetFolderPath: targetFolderPath,
-                       useSSH: useSSH)
-                .body(context)
-            
-            try jekyllDisablingFile.delete()
-            
-            let ghPagesModeName : String
-            switch source {
-            case .master : ghPagesModeName = "master branch"
-            case .masterDocs : ghPagesModeName = "master branch /docs folder"
-            case .ghPages : ghPagesModeName = "gh-pages branch"
-            }
-            
-            let settingsURL = "\(gitHubRemote(repository: repository, useSSH: false, useStandardRepoURL: false))/settings"
-            
-            CommandLine.output("Remember to set your GitHub Pages source to \"\(ghPagesModeName)\" at \(settingsURL)",
-                as: .info)
-        }
-    }
-    
-    private static func gitHubRemote(repository: String, useSSH: Bool, useStandardRepoURL: Bool = true) -> String {
         let prefix = useSSH ? "git@github.com:" : "https://github.com/"
-        let suffix = useStandardRepoURL ? ".git" : ""
-        return "\(prefix)\(repository)\(suffix)"
-    }
-    
-    enum GitHubPagesDeploymentMode {
-        case master, ghPages, masterDocs
+        return git(
+            "\(prefix)\(repository).git",
+            branch: branch,
+            targetFolderPath: targetFolderPath
+        )
     }
 }

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -100,7 +100,7 @@ public extension DeploymentMethod {
     {
         let remote = gitHubRemote(repository: repository, useSSH: useSSH)
         
-        return DeploymentMethod(name: "GitHub Pages (\(remote)") { context in
+        return DeploymentMethod(name: "GitHub Pages (\(remote))") { context in
             let jekyllDisablingFile = try context.createOutputFile(at: Path(".nojekyll"))
             
             let branchName : String

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -36,7 +36,7 @@ public struct DeploymentMethod<Site: Website> {
 public extension DeploymentMethod {
     /// Deploy a website to a given remote using Git.
     /// - parameter remote: The full address of the remote to deploy to.
-    static func git(_ remote: String) -> Self {
+    static func git(_ remote: String, branch: String = "master") -> Self {
         DeploymentMethod(name: "Git (\(remote))") { context in
             let folder = try context.createDeploymentFolder(withPrefix: "Git") { folder in
                 if !folder.containsSubfolder(named: ".git") {
@@ -54,7 +54,7 @@ public extension DeploymentMethod {
                 )
 
                 _ = try? shellOut(
-                    to: .gitPull(remote: "origin", branch: "master"),
+                    to: .gitPull(remote: "origin", branch: branch),
                     at: folder.path
                 )
 
@@ -74,7 +74,7 @@ public extension DeploymentMethod {
                 )
 
                 try shellOut(
-                    to: .gitPush(remote: "origin", branch: "master"),
+                    to: .gitPush(remote: "origin", branch: branch),
                     at: folder.path
                 )
             } catch let error as ShellOutError {
@@ -88,8 +88,8 @@ public extension DeploymentMethod {
     /// Deploy a website to a given GitHub repository.
     /// - parameter repository: The full name of the repository (including its username).
     /// - parameter useSSH: Whether an SSH connection should be used (preferred).
-    static func gitHub(_ repository: String, useSSH: Bool = true) -> Self {
+    static func gitHub(_ repository: String, branch: String = "master", useSSH: Bool = true) -> Self {
         let prefix = useSSH ? "git@github.com:" : "https://github.com/"
-        return git("\(prefix)\(repository).git")
+        return git("\(prefix)\(repository).git", branch: branch)
     }
 }

--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -160,12 +160,15 @@ public extension PublishingContext {
             )
         }
 
-        try outputFolderPath.flatMap { try? folder.subfolder(at: $0.string) }?.delete()
-        let targetFolder = outputFolderPath.flatMap { try? folder.createSubfolder(at: $0.string) } ?? folder
+        var outputFolder = folder
+
+        if let outputFolderPath = outputFolderPath {
+            outputFolder = try folder.createSubfolder(at: outputFolderPath.string)
+        }
 
         do {
-            try folders.output.subfolders.forEach { try $0.copy(to: targetFolder) }
-            try folders.output.files.includingHidden.forEach { try $0.copy(to: targetFolder) }
+            try folders.output.subfolders.forEach { try $0.copy(to: outputFolder) }
+            try folders.output.files.includingHidden.forEach { try $0.copy(to: outputFolder) }
             return folder
         } catch {
             throw FileIOError(path: path, reason: .folderCreationFailed)

--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -159,7 +159,7 @@ public extension PublishingContext {
 
         do {
             try folders.output.subfolders.forEach { try $0.copy(to: folder) }
-            try folders.output.files.forEach { try $0.copy(to: folder) }
+            try folders.output.files.includingHidden.forEach { try $0.copy(to: folder) }
             return folder
         } catch {
             throw FileIOError(path: path, reason: .folderCreationFailed)

--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -138,12 +138,12 @@ public extension PublishingContext {
     /// After that, all output files and folders will be copied into the new folder.
     /// - Parameter prefix: What prefix to apply to the folder, typically
     ///   the name of the current deployment method.
-    /// - parameter targetFolderPath: Any specific subfolder path to copy the output to.
+    /// - parameter outputFolderPath: Any specific subfolder path to copy the output to.
     ///   If `nil`, then the output will be copied to the deployment folder itself.
     /// - Parameter configure: A closure used to configure the folder.
     func createDeploymentFolder(
         withPrefix prefix: String,
-        targetFolderPath: Path? = nil,
+        outputFolderPath: Path? = nil,
         configure: (Folder) throws -> Void
     ) throws -> Folder {
         let path = Path(prefix + "Deploy")
@@ -160,8 +160,8 @@ public extension PublishingContext {
             )
         }
 
-        try targetFolderPath.flatMap { try? folder.subfolder(at: $0.string) }?.delete()
-        let targetFolder = targetFolderPath.flatMap { try? folder.createSubfolder(at: $0.string) } ?? folder
+        try outputFolderPath.flatMap { try? folder.subfolder(at: $0.string) }?.delete()
+        let targetFolder = outputFolderPath.flatMap { try? folder.createSubfolder(at: $0.string) } ?? folder
 
         do {
             try folders.output.subfolders.forEach { try $0.copy(to: targetFolder) }

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -114,6 +114,38 @@ final class DeploymentTests: PublishTestCase {
         XCTAssertTrue(infoMessage.contains("receive.denyCurrentBranch"))
         XCTAssertTrue(infoMessage.contains("[remote rejected]"))
     }
+
+    func testDeployingUsingCustomOutputFolder() throws {
+        let container = try Folder.createTemporary()
+
+        // First generate
+        try publishWebsite(in: container, using: [
+            .addMarkdownFiles(),
+            .generateHTML(withTheme: .foundation)
+        ], content: [
+            "one/a.md": "Text"
+        ])
+
+        // Then deploy
+        CommandLine.arguments.append("--deploy")
+
+        var outputFolder: Folder?
+
+        try publishWebsite(in: container, using: [
+            .deploy(using: DeploymentMethod(name: "Test") { context in
+                outputFolder = try context.createDeploymentFolder(
+                    withPrefix: "Test",
+                    outputFolderPath: "CustomOutput",
+                    configure: { _ in }
+                )
+            })
+        ])
+
+        let folder = try require(outputFolder)
+        let subfolder = try folder.subfolder(named: "CustomOutput")
+        print(subfolder.subfolders.recursive)
+        XCTAssertTrue(subfolder.containsSubfolder(at: "one/a"))
+    }
 }
 
 extension DeploymentTests {
@@ -122,7 +154,8 @@ extension DeploymentTests {
             ("testDeploymentSkippedByDefault", testDeploymentSkippedByDefault),
             ("testGenerationStepsAndPluginsSkippedWhenDeploying", testGenerationStepsAndPluginsSkippedWhenDeploying),
             ("testGitDeploymentMethod", testGitDeploymentMethod),
-            ("testGitDeploymentMethodWithError",testGitDeploymentMethodWithError)
+            ("testGitDeploymentMethodWithError", testGitDeploymentMethodWithError),
+            ("testDeployingUsingCustomOutputFolder", testDeployingUsingCustomOutputFolder)
         ]
     }
 }

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -143,7 +143,6 @@ final class DeploymentTests: PublishTestCase {
 
         let folder = try require(outputFolder)
         let subfolder = try folder.subfolder(named: "CustomOutput")
-        print(subfolder.subfolders.recursive)
         XCTAssertTrue(subfolder.containsSubfolder(at: "one/a"))
     }
 }

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -81,63 +81,6 @@ final class DeploymentTests: PublishTestCase {
         XCTAssertFalse(try indexFile.readAsString().isEmpty)
     }
 
-    func testGitDeploymentMethodWithAnotherBranch() throws {
-        let container = try Folder.createTemporary()
-        let remote = try container.createSubfolder(named: "Remote.git")
-        let repo = try container.createSubfolder(named: "Repo")
-
-        try shellOut(to: [
-            "git init",
-            "git config --local receive.denyCurrentBranch updateInstead"
-        ], at: remote.path)
-
-        // First generate
-        try publishWebsite(in: repo, using: [
-            .generateHTML(withTheme: .foundation)
-        ])
-
-        // Then deploy
-        CommandLine.arguments.append("--deploy")
-
-        try publishWebsite(in: repo, using: [
-            .deploy(using: .git(remote.path, branch: "develop"))
-        ])
-
-        try shellOut(to: .gitCheckout(branch: "develop"), at: remote.path)
-        let indexFile = try remote.file(named: "index.html")
-        XCTAssertFalse(try indexFile.readAsString().isEmpty)
-    }
-
-    func testGitDeploymentMethodInSubfolder() throws {
-        let container = try Folder.createTemporary()
-        let remote = try container.createSubfolder(named: "Remote.git")
-        let repo = try container.createSubfolder(named: "Repo")
-
-        try shellOut(to: [
-            "git init",
-            "git config --local receive.denyCurrentBranch updateInstead",
-            "echo words > existingFile.txt"
-        ], at: remote.path)
-
-        // First generate
-        try publishWebsite(in: repo, using: [
-            .generateHTML(withTheme: .foundation)
-        ])
-
-        // Then deploy
-        CommandLine.arguments.append("--deploy")
-
-        try publishWebsite(in: repo, using: [
-            .deploy(using: .git(remote.path, targetFolderPath: Path("docs/content")))
-        ])
-
-        let indexFile = try remote.subfolder(at: "docs").subfolder(at: "content").file(named: "index.html")
-        XCTAssertFalse(try indexFile.readAsString().isEmpty)
-
-        let existingFile = try remote.file(named: "existingFile.txt")
-        XCTAssertFalse(try existingFile.readAsString().isEmpty)
-    }
-
 	func testGitDeploymentMethodWithError() throws {
         let container = try Folder.createTemporary()
         let remote = try container.createSubfolder(named: "Remote.git")
@@ -179,8 +122,6 @@ extension DeploymentTests {
             ("testDeploymentSkippedByDefault", testDeploymentSkippedByDefault),
             ("testGenerationStepsAndPluginsSkippedWhenDeploying", testGenerationStepsAndPluginsSkippedWhenDeploying),
             ("testGitDeploymentMethod", testGitDeploymentMethod),
-            ("testGitDeploymentMethodWithAnotherBranch", testGitDeploymentMethodWithAnotherBranch),
-            ("testGitDeploymentMethodInSubfolder", testGitDeploymentMethodInSubfolder),
             ("testGitDeploymentMethodWithError",testGitDeploymentMethodWithError)
         ]
     }


### PR DESCRIPTION
This is a continuation of PR #74 and following the plan outlined [here](https://github.com/JohnSundell/Publish/pull/74#issuecomment-627321541)

- Added a branch parameter to Git/GitHub deployment method
- Enabled usage of custom dot files inside deployment methods
- Added a custom path for deployment folder content ( thanks @john-mueller )

All of this should enable more possibilities for deployments and custom deployment methods