### PR TITLE
CLI: Add plugin project generation command

### DIFF
--- a/Sources/PublishCLI/main.swift
+++ b/Sources/PublishCLI/main.swift
@@ -15,7 +15,7 @@ let cli = CLI(
     publishRepositoryURL: URL(
         string: "https://github.com/johnsundell/publish.git"
     )!,
-    publishVersion: "0.3.0"
+    publishVersion: "0.6.0"
 )
 
 do {

--- a/Sources/PublishCLICore/CLI.swift
+++ b/Sources/PublishCLICore/CLI.swift
@@ -31,7 +31,8 @@ public struct CLI {
             let generator = ProjectGenerator(
                 folder: folder,
                 publishRepositoryURL: publishRepositoryURL,
-                publishVersion: publishVersion
+                publishVersion: publishVersion,
+                kind: resolveProjectKind(from: arguments)
             )
 
             try generator.generate()
@@ -85,5 +86,13 @@ private extension CLI {
             }
         }
         return 8000 // default portNumber
+    }
+
+    private func resolveProjectKind(from arguments: [String]) -> ProjectKind {
+        guard arguments.count > 2 else {
+            return .website
+        }
+
+        return ProjectKind(rawValue: arguments[2]) ?? .website
     }
 }

--- a/Sources/PublishCLICore/ProjectGenerator.swift
+++ b/Sources/PublishCLICore/ProjectGenerator.swift
@@ -11,15 +11,18 @@ internal struct ProjectGenerator {
     private let folder: Folder
     private let publishRepositoryURL: URL
     private let publishVersion: String
-    private let siteName: String
+    private let kind: ProjectKind
+    private let name: String
 
     init(folder: Folder,
          publishRepositoryURL: URL,
-         publishVersion: String) {
+         publishVersion: String,
+         kind: ProjectKind) {
         self.folder = folder
         self.publishRepositoryURL = publishRepositoryURL
         self.publishVersion = publishVersion
-        self.siteName = folder.name.asSiteName()
+        self.kind = kind
+        self.name = folder.name.asProjectName()
     }
 
     func generate() throws {
@@ -28,13 +31,19 @@ internal struct ProjectGenerator {
         }
 
         try generateGitIgnore()
-        try generateResourcesFolder()
-        try generateContentFolder()
         try generatePackageFile()
-        try generateMainFile()
+
+        switch kind {
+        case .website:
+            try generateResourcesFolder()
+            try generateContentFolder()
+            try generateMainFile()
+        case .plugin:
+            try generatePluginBoilerplate()
+        }
 
         print("""
-        ✅ Generated website project for '\(siteName)'
+        ✅ Generated \(kind.rawValue) project for '\(name)'
         Run 'open Package.swift' to open it and start building
         """)
     }
@@ -58,7 +67,7 @@ private extension ProjectGenerator {
 
     func generateContentFolder() throws {
         let folder = try self.folder.createSubfolder(named: "Content")
-        try folder.createIndexFile(withMarkdown: "# Welcome to \(siteName)!")
+        try folder.createIndexFile(withMarkdown: "# Welcome to \(name)!")
 
         let postsFolder = try folder.createSubfolder(named: "posts")
         try postsFolder.createIndexFile(withMarkdown: "# My posts")
@@ -85,28 +94,31 @@ private extension ProjectGenerator {
 
         if repositoryURL.hasPrefix("http") || repositoryURL.hasPrefix("git@") {
             dependencyString = """
-            url: "\(repositoryURL)", from: "\(publishVersion)"
+            name: "Publish", url: "\(repositoryURL)", from: "\(publishVersion)"
             """
         } else {
             dependencyString = "path: \"\(publishRepositoryURL.path)\""
         }
 
         try folder.createFile(named: "Package.swift").write("""
-        // swift-tools-version:5.1
+        // swift-tools-version:5.2
 
         import PackageDescription
 
         let package = Package(
-            name: "\(siteName)",
+            name: "\(name)",
             products: [
-                .executable(name: "\(siteName)", targets: ["\(siteName)"])
+                .\(kind.buildProduct)(
+                    name: "\(name)",
+                    targets: ["\(name)"]
+                )
             ],
             dependencies: [
                 .package(\(dependencyString))
             ],
             targets: [
                 .target(
-                    name: "\(siteName)",
+                    name: "\(name)",
                     dependencies: ["Publish"]
                 )
             ]
@@ -115,7 +127,7 @@ private extension ProjectGenerator {
     }
 
     func generateMainFile() throws {
-        let path = "Sources/\(siteName)/main.swift"
+        let path = "Sources/\(name)/main.swift"
 
         try folder.createFileIfNeeded(at: path).write("""
         import Foundation
@@ -123,7 +135,7 @@ private extension ProjectGenerator {
         import Plot
 
         // This type acts as the configuration for your website.
-        struct \(siteName): Website {
+        struct \(name): Website {
             enum SectionID: String, WebsiteSectionID {
                 // Add the sections that you want your website to contain here:
                 case posts
@@ -135,15 +147,44 @@ private extension ProjectGenerator {
 
             // Update these properties to configure your website:
             var url = URL(string: "https://your-website-url.com")!
-            var name = "\(siteName)"
-            var description = "A description of \(siteName)"
+            var name = "\(name)"
+            var description = "A description of \(name)"
             var language: Language { .english }
             var imagePath: Path? { nil }
         }
 
         // This will generate your website using the built-in Foundation theme:
-        try \(siteName)().publish(withTheme: .foundation)
+        try \(name)().publish(withTheme: .foundation)
         """)
+    }
+
+    func generatePluginBoilerplate() throws {
+        let path = "Sources/\(name)/\(name).swift"
+        let methodName = name[name.startIndex].lowercased() + name.dropFirst()
+
+        try folder.createFileIfNeeded(at: path).write("""
+        import Publish
+
+        public extension Plugin {
+            /// Documentation for your plugin
+            static func \(methodName)() -> Self {
+                Plugin(name: "\(name)") { context in
+                    // Perform your plugin's work
+                }
+            }
+        }
+        """)
+    }
+}
+
+private extension ProjectKind {
+    var buildProduct: String {
+        switch self {
+        case .website:
+            return "executable"
+        case .plugin:
+            return "library"
+        }
     }
 }
 
@@ -154,7 +195,7 @@ private extension Folder {
 }
 
 private extension String {
-    func asSiteName() -> Self {
+    func asProjectName() -> Self {
         let validCharacters = CharacterSet.alphanumerics
         let validEdgeCharacters = CharacterSet.letters
         let validSegments = trimmingCharacters(in: validEdgeCharacters.inverted)

--- a/Sources/PublishCLICore/ProjectGenerator.swift
+++ b/Sources/PublishCLICore/ProjectGenerator.swift
@@ -94,7 +94,7 @@ private extension ProjectGenerator {
 
         if repositoryURL.hasPrefix("http") || repositoryURL.hasPrefix("git@") {
             dependencyString = """
-            name: "Publish", url: "\(repositoryURL)", from: "\(publishVersion)"
+            url: "\(repositoryURL)", from: "\(publishVersion)"
             """
         } else {
             dependencyString = "path: \"\(publishRepositoryURL.path)\""
@@ -114,7 +114,7 @@ private extension ProjectGenerator {
                 )
             ],
             dependencies: [
-                .package(\(dependencyString))
+                .package(name: "Publish", \(dependencyString))
             ],
             targets: [
                 .target(

--- a/Sources/PublishCLICore/ProjectKind.swift
+++ b/Sources/PublishCLICore/ProjectKind.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+internal enum ProjectKind: String {
+    case website
+    case plugin
+}

--- a/Tests/PublishTests/Tests/CLITests.swift
+++ b/Tests/PublishTests/Tests/CLITests.swift
@@ -10,11 +10,24 @@ import Files
 import ShellOut
 
 final class CLITests: PublishTestCase {
-    func testProjectGeneration() throws {
+    func testWebsiteProjectGeneration() throws {
         #if INCLUDE_CLI
         let folder = try Folder.createTemporary()
         try makeCLI(in: folder, command: "new").run(in: folder)
         try makeCLI(in: folder, command: "generate").run(in: folder)
+        #endif
+    }
+
+    func testPluginProjectGeneration() throws {
+        #if INCLUDE_CLI
+        let folder = try Folder.createTemporary(named: "Name")
+        try makeCLI(in: folder, command: "new", "plugin").run(in: folder)
+
+        XCTAssertTrue(folder.containsFile(at: "Sources/Name/Name.swift"))
+        XCTAssertEqual(try folder.getPackageName(), "Name")
+
+        // Make sure that the project can build
+        try shellOut(to: "swift build", at: folder.path)
         #endif
     }
 
@@ -79,7 +92,8 @@ final class CLITests: PublishTestCase {
 extension CLITests {
     static var allTests: Linux.TestList<CLITests> {
         [
-            ("testProjectGeneration", testProjectGeneration),
+            ("testWebsiteProjectGeneration", testWebsiteProjectGeneration),
+            ("testPluginProjectGeneration", testPluginProjectGeneration),
             ("testSiteName", testSiteName),
             ("testSiteNameFromLowercasedFolderName", testSiteNameFromLowercasedFolderName),
             ("testSiteNameFromFolderNameStartingWithDigit", testSiteNameFromFolderNameStartingWithDigit),
@@ -92,7 +106,7 @@ extension CLITests {
 }
 
 private extension CLITests {
-    func makeCLI(in folder: Folder, command: String) throws -> CLI {
+    func makeCLI(in folder: Folder, command: String...) throws -> CLI {
         let thisFile = try File(path: "\(#file)")
         let pathSuffix = "/Tests/PublishTests/Tests/CLITests.swift"
 
@@ -101,7 +115,7 @@ private extension CLITests {
         )
 
         return CLI(
-            arguments: [folder.path, command],
+            arguments: [folder.path] + command,
             publishRepositoryURL: URL(
                 fileURLWithPath: repositoryFolder.path
             ),


### PR DESCRIPTION
This change makes it possible to run ‘publish new plugin’ in a folder to generate a plugin project. While plugins are just normal Swift packages, this makes it faster to get started building plugins.

The Swift tools version was also bumped to 5.2 for generated projects (to match Publish itself), and the minimum Publish version has been bumped to 0.6.0 (the latest release at this point).