### PR TITLE
Add draft support for Markdown Content

### DIFF
--- a/Sources/Publish/API/Content.swift
+++ b/Sources/Publish/API/Content.swift
@@ -17,7 +17,7 @@ public struct Content: Hashable, ContentProtocol {
     public var imagePath: Path?
     public var audio: Audio?
     public var video: Video?
-    public var draft: Bool
+    public var isDraft: Bool
 
     /// Initialize a new instance of this type
     /// - parameter title: The location's title.
@@ -28,7 +28,7 @@ public struct Content: Hashable, ContentProtocol {
     /// - parameter imagePath: A path to any image for the location.
     /// - parameter audio: Any audio data associated with this content.
     /// - parameter video: Any video data associated with this content.
-    /// - parameter draft: Is Content a draft.
+    /// - parameter isDraft: Is Content a draft.
     public init(title: String = "",
                 description: String = "",
                 body: Body = Body(html: ""),
@@ -37,7 +37,7 @@ public struct Content: Hashable, ContentProtocol {
                 imagePath: Path? = nil,
                 audio: Audio? = nil,
                 video: Video? = nil,
-                draft: Bool = false) {
+                isDraft: Bool = false) {
         self.title = title
         self.description = description
         self.body = body
@@ -46,7 +46,7 @@ public struct Content: Hashable, ContentProtocol {
         self.imagePath = imagePath
         self.audio = audio
         self.video = video
-        self.draft = draft
+        self.isDraft = isDraft
     }
 }
 

--- a/Sources/Publish/API/Content.swift
+++ b/Sources/Publish/API/Content.swift
@@ -17,6 +17,7 @@ public struct Content: Hashable, ContentProtocol {
     public var imagePath: Path?
     public var audio: Audio?
     public var video: Video?
+    public var draft: Bool
 
     /// Initialize a new instance of this type
     /// - parameter title: The location's title.
@@ -27,6 +28,7 @@ public struct Content: Hashable, ContentProtocol {
     /// - parameter imagePath: A path to any image for the location.
     /// - parameter audio: Any audio data associated with this content.
     /// - parameter video: Any video data associated with this content.
+    /// - parameter draft: Is Content a draft.
     public init(title: String = "",
                 description: String = "",
                 body: Body = Body(html: ""),
@@ -34,7 +36,8 @@ public struct Content: Hashable, ContentProtocol {
                 lastModified: Date = Date(),
                 imagePath: Path? = nil,
                 audio: Audio? = nil,
-                video: Video? = nil) {
+                video: Video? = nil,
+                draft: Bool = false) {
         self.title = title
         self.description = description
         self.body = body
@@ -43,6 +46,7 @@ public struct Content: Hashable, ContentProtocol {
         self.imagePath = imagePath
         self.audio = audio
         self.video = video
+        self.draft = draft
     }
 }
 

--- a/Sources/Publish/Internal/MarkdownContentFactory.swift
+++ b/Sources/Publish/Internal/MarkdownContentFactory.swift
@@ -67,6 +67,7 @@ private extension MarkdownContentFactory {
         let imagePath = try decoder.decodeIfPresent("image", as: Path.self)
         let audio = try decoder.decodeIfPresent("audio", as: Audio.self)
         let video = try decoder.decodeIfPresent("video", as: Video.self)
+        let draft = try decoder.decodeIfPresent("draft", as: Bool.self) ?? false
 
         return Content(
             title: title ?? markdown.title ?? file.nameExcludingExtension,
@@ -76,7 +77,8 @@ private extension MarkdownContentFactory {
             lastModified: lastModified,
             imagePath: imagePath,
             audio: audio,
-            video: video
+            video: video,
+            draft: draft
         )
     }
 

--- a/Sources/Publish/Internal/MarkdownContentFactory.swift
+++ b/Sources/Publish/Internal/MarkdownContentFactory.swift
@@ -67,7 +67,7 @@ private extension MarkdownContentFactory {
         let imagePath = try decoder.decodeIfPresent("image", as: Path.self)
         let audio = try decoder.decodeIfPresent("audio", as: Audio.self)
         let video = try decoder.decodeIfPresent("video", as: Video.self)
-        let draft = try decoder.decodeIfPresent("draft", as: Bool.self) ?? false
+        let isDraft = try decoder.decodeIfPresent("draft", as: Bool.self) ?? false
 
         return Content(
             title: title ?? markdown.title ?? file.nameExcludingExtension,
@@ -78,7 +78,7 @@ private extension MarkdownContentFactory {
             imagePath: imagePath,
             audio: audio,
             video: video,
-            draft: draft
+            isDraft: isDraft
         )
     }
 

--- a/Sources/Publish/Internal/MarkdownFileHandler.swift
+++ b/Sources/Publish/Internal/MarkdownFileHandler.swift
@@ -59,7 +59,7 @@ internal struct MarkdownFileHandler<Site: Website> {
                         sectionID: sectionID
                     )
 
-                    if item.content.draft == false {
+                    if item.content.isDraft == false {
                         context.addItem(item)
                     }
                     

--- a/Sources/Publish/Internal/MarkdownFileHandler.swift
+++ b/Sources/Publish/Internal/MarkdownFileHandler.swift
@@ -59,7 +59,10 @@ internal struct MarkdownFileHandler<Site: Website> {
                         sectionID: sectionID
                     )
 
-                    context.addItem(item)
+                    if item.content.draft == false {
+                        context.addItem(item)
+                    }
+                    
                 } catch {
                     let path = Path(file.path(relativeTo: folder))
                     throw wrap(error, forPath: path)


### PR DESCRIPTION
this adds support for a **_draft_** property in your Markdown files

`draft: true`

This can mark content as Work-in-Progress that should not yet be included in your build site.

Site is build just from non-draft content then

default is draft = false for not defined property