### PR TITLE
Add clean command to CLI

### DIFF
--- a/Sources/PublishCLICore/CLI.swift
+++ b/Sources/PublishCLICore/CLI.swift
@@ -46,6 +46,9 @@ public struct CLI {
             let portNumber = extractPortNumber(from: arguments)
             let runner = WebsiteRunner(folder: folder, portNumber: portNumber)
             try runner.run()
+        case "clean":
+            let cleaner = ProjectCleaner(folder: folder)
+            try cleaner.clean()
         default:
             outputHelpText()
         }
@@ -70,6 +73,8 @@ private extension CLI {
                or "--port" option for customizing the default port.
         - deploy: Generate and deploy the website in the current
                folder, according to its deployment method.
+        - clean: Remove the .build folder from the project and all files
+                 and folders inside of it.
         """)
     }
 

--- a/Sources/PublishCLICore/ProjectCleaner.swift
+++ b/Sources/PublishCLICore/ProjectCleaner.swift
@@ -1,0 +1,27 @@
+/**
+*  Publish
+*  Copyright (c) John Sundell 2019
+*  MIT license, see LICENSE file for details
+*/
+
+import Files
+import Foundation
+import ShellOut
+
+internal struct ProjectCleaner {
+
+    private let folder: Folder
+
+    init(folder: Folder) {
+        self.folder = folder
+    }
+
+    func clean() throws {
+        try shellOut(
+            to: "rm -rf .build/",
+            at: folder.path,
+            outputHandle: FileHandle.standardOutput,
+            errorHandle: FileHandle.standardError
+        )
+    }
+}


### PR DESCRIPTION
Occasionally `$ publish run` fails due to duplicate files inside the `.build` folder. This might be a problem on my machine since I have seen this behavior before. However, having a `clean` command would be nice in the event others are experiencing this and want to have a fresh build next time they run `$ publish run`.