### PR TITLE
Fix namespacing issue for websites with name "Website".

### DIFF
--- a/Sources/PublishCLICore/ProjectGenerator.swift
+++ b/Sources/PublishCLICore/ProjectGenerator.swift
@@ -129,7 +129,7 @@ private extension ProjectGenerator {
     func generateMainFile() throws {
         let path = "Sources/\(name)/main.swift"
 
-        let websiteProtocol = name == "Website" ? "Publish.Website" : "Website"
+        let websiteProtocol = (name == "Website") ? "Publish.Website" : "Website"
         try folder.createFileIfNeeded(at: path).write("""
         import Foundation
         import Publish

--- a/Sources/PublishCLICore/ProjectGenerator.swift
+++ b/Sources/PublishCLICore/ProjectGenerator.swift
@@ -129,13 +129,14 @@ private extension ProjectGenerator {
     func generateMainFile() throws {
         let path = "Sources/\(name)/main.swift"
 
+        let websiteProtocol = name == "Website" ? "Publish.Website" : "Website"
         try folder.createFileIfNeeded(at: path).write("""
         import Foundation
         import Publish
         import Plot
 
         // This type acts as the configuration for your website.
-        struct \(name): Website {
+        struct \(name): \(websiteProtocol) {
             enum SectionID: String, WebsiteSectionID {
                 // Add the sections that you want your website to contain here:
                 case posts


### PR DESCRIPTION
Hi,

Wanted to test Publish and wasn't very original in naming and run command `publish new` in folder called "Website".
Obviously it created `struct Website: Website`.
This PR changes protocol name to `Publish.Website`, if struct name is `Website`.