### PR TITLE
Allow user to have draft content excluded from Output

### DIFF
--- a/Sources/Publish/API/Content.swift
+++ b/Sources/Publish/API/Content.swift
@@ -17,6 +17,7 @@ public struct Content: Hashable, ContentProtocol {
     public var imagePath: Path?
     public var audio: Audio?
     public var video: Video?
+    public var isDraft: Bool
 
     /// Initialize a new instance of this type
     /// - parameter title: The location's title.
@@ -27,6 +28,7 @@ public struct Content: Hashable, ContentProtocol {
     /// - parameter imagePath: A path to any image for the location.
     /// - parameter audio: Any audio data associated with this content.
     /// - parameter video: Any video data associated with this content.
+    /// - parameter isDraft: Whether the content is ready to be published.
     public init(title: String = "",
                 description: String = "",
                 body: Body = Body(html: ""),
@@ -34,7 +36,8 @@ public struct Content: Hashable, ContentProtocol {
                 lastModified: Date = Date(),
                 imagePath: Path? = nil,
                 audio: Audio? = nil,
-                video: Video? = nil) {
+                video: Video? = nil,
+                isDraft: Bool = false) {
         self.title = title
         self.description = description
         self.body = body
@@ -43,6 +46,7 @@ public struct Content: Hashable, ContentProtocol {
         self.imagePath = imagePath
         self.audio = audio
         self.video = video
+        self.isDraft = isDraft
     }
 }
 

--- a/Sources/Publish/Internal/MarkdownContentFactory.swift
+++ b/Sources/Publish/Internal/MarkdownContentFactory.swift
@@ -67,6 +67,7 @@ private extension MarkdownContentFactory {
         let imagePath = try decoder.decodeIfPresent("image", as: Path.self)
         let audio = try decoder.decodeIfPresent("audio", as: Audio.self)
         let video = try decoder.decodeIfPresent("video", as: Video.self)
+        let isDraft = try decoder.decodeIfPresent("isDraft", as: Bool.self)
 
         return Content(
             title: title ?? markdown.title ?? file.nameExcludingExtension,
@@ -76,7 +77,8 @@ private extension MarkdownContentFactory {
             lastModified: lastModified,
             imagePath: imagePath,
             audio: audio,
-            video: video
+            video: video,
+            isDraft: isDraft ?? false
         )
     }
 

--- a/Sources/Publish/Internal/MarkdownFileHandler.swift
+++ b/Sources/Publish/Internal/MarkdownFileHandler.swift
@@ -39,7 +39,9 @@ internal struct MarkdownFileHandler<Site: Website> {
 
                 if file.nameExcludingExtension == "index", file.parent == subfolder {
                     let content = try factory.makeContent(fromFile: file)
-                    context.sections[sectionID].content = content
+                    if !content.isDraft {
+                        context.sections[sectionID].content = content
+                    }
                     continue
                 }
 

--- a/Sources/Publish/Internal/MarkdownFileHandler.swift
+++ b/Sources/Publish/Internal/MarkdownFileHandler.swift
@@ -36,12 +36,13 @@ internal struct MarkdownFileHandler<Site: Website> {
 
             for file in subfolder.files.recursive {
                 guard file.isMarkdown else { continue }
+                if let content = try? factory.makeContent(fromFile: file), content.isDraft {
+                    continue
+                }
 
                 if file.nameExcludingExtension == "index", file.parent == subfolder {
                     let content = try factory.makeContent(fromFile: file)
-                    if !content.isDraft {
-                        context.sections[sectionID].content = content
-                    }
+                    context.sections[sectionID].content = content
                     continue
                 }
 


### PR DESCRIPTION
It would be beneficial to be able to write up a draft and keep it in the project along with the published content. By setting `isDraft` to `true`, the content will not be included in the Output. The default value for `isDraft` is `false`.

```
article.md
---
date: 2020-08-24 09:00
description: My description
tags: mytag
image: images/image.jpg
isDraft: true
---
# Some title
```