### PR TITLE
Fix incorrect version in PublishCLI/main.swift

### DIFF
--- a/Sources/PublishCLI/main.swift
+++ b/Sources/PublishCLI/main.swift
@@ -15,7 +15,7 @@ let cli = CLI(
     publishRepositoryURL: URL(
         string: "https://github.com/johnsundell/publish.git"
     )!,
-    publishVersion: "0.6.0"
+    publishVersion: "0.7.0"
 )
 
 do {


### PR DESCRIPTION
This file refers to Publish 0.6.0, which leads to generating new projects with templates that depend on 0.6.0. This doesn't seem to be right, as the latest version is 0.7.0.