### PR TITLE
Fix horizontal scrolling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,10 @@ extension Theme where Site == DeliciousRecipes {
 
     private struct DeliciousHTMLFactory: HTMLFactory {
         ...
-        func makeItemHTML(for item: Item<DeliciousRecipes>,
-                          context: PublishingContext<DeliciousRecipes>) throws -> HTML {
+        func makeItemHTML(
+            for item: Item<DeliciousRecipes>,
+            context: PublishingContext<DeliciousRecipes>
+        ) throws -> HTML {
             HTML(
                 .head(for: item, on: context.site),
                 .body(


### PR DESCRIPTION
Current code formatting in the themes snippet requires horizontal scrolling. If it's slightly reformatted, horizontal scrolling can be avoided improving readability.