### PR TITLE
Change localhost server to SwiftNIO

### DIFF
--- a/Documentation/HowTo/running-localhost-server-in-xcode.md.md
+++ b/Documentation/HowTo/running-localhost-server-in-xcode.md.md
@@ -1,0 +1,30 @@
+#  Running localhost server in Xcode
+
+If you haven't already open package containing your website in Xcode.
+You can do it by either running `open Package.swift` in terminal or double clicking `Package.swift` in Finder.
+
+After Xcode fetches all package dependencies you should see the default build sheme.
+(It's the name of your website right to the run button on the toolbar.)
+
+## Creating run scheme
+
+1. Click the build scheme and select "Edit scheme..." from the dropdown.
+2. Small window will appear. In it click "Duplicate Scheme" and select name for your run scheme, for example "Run [nameOfYourPage]"
+3. From left pane select Run
+4. Change the executable to `publish-cli`
+5. Then in Arguments tab add `run` to "Arguments Passed on launch"
+6. Lastly in Options tab check "Use custom working directory:" option and select folder containing your `Package.swift` file
+7. Click "Close" to close the small window
+
+Now you can run your project (`Cmd+R` or press Run button on the toolbar) and your website will be built and served locally.
+
+## Going back to publishing
+
+Because we didn't delete the original build scheme you can select it from the dropdown by clicking the name of your run scheme and selecting the original one.
+
+## Changing the port
+
+Because baisicly we are just running `publish run` in more complicated way, we can of course change the port on which the website is served.
+
+To do this change `run` from step 5 to `run -p PORT` (eg. `run -p 1337`).
+Or add `-p PORT` as another argument passed on launch.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -15,5 +15,6 @@ Shorter articles focused on explaining how to get a given task done using Publis
 - [Expressing custom metadata values using Markdown](HowTo/custom-markdown-metadata-values.md)
 - [Nesting items within folders](HowTo/nested-items.md)
 - [Using a custom `DateFormatter`](HowTo/using-a-custom-date-formatter.md)
+- [Running localhost server in Xcode](HowTo/running-localhost-server-in-xcode.md)
 
 *Contributions adding more “How to” articles, or other kinds of documentation, are more than welcome.*

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/johnsundell/files.git",
         "state": {
           "branch": null,
-          "revision": "22fe84797d499ffca911ccd896b34efaf06a50b9",
-          "version": "4.1.1"
+          "revision": "d273b5b7025d386feef79ef6bad7de762e106eaf",
+          "version": "4.2.0"
         }
       },
       {
@@ -47,12 +47,39 @@
         }
       },
       {
+        "package": "StaticServer",
+        "repositoryURL": "https://github.com/Mastermakrela/Static-Server",
+        "state": {
+          "branch": null,
+          "revision": "a02ebacf828ba4c4a072fef7cdc26389dc93d108",
+          "version": "0.0.4"
+        }
+      },
+      {
         "package": "Sweep",
         "repositoryURL": "https://github.com/johnsundell/sweep.git",
         "state": {
           "branch": null,
           "revision": "801c2878e4c6c5baf32fe132e1f3f3af6f9fd1b0",
           "version": "0.4.0"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+          "version": "0.3.1"
+        }
+      },
+      {
+        "package": "swift-nio",
+        "repositoryURL": "https://github.com/apple/swift-nio.git",
+        "state": {
+          "branch": null,
+          "revision": "2bae395344d41710dffab456265d534d7dc34ab8",
+          "version": "2.25.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/Mastermakrela/Static-Server",
         "state": {
           "branch": null,
-          "revision": "a02ebacf828ba4c4a072fef7cdc26389dc93d108",
-          "version": "0.0.4"
+          "revision": "e8b90a85878111dd835263cc030d541eb6e5fd90",
+          "version": "0.0.5"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
         .package(name: "Files", url: "https://github.com/johnsundell/files.git", from: "4.0.0"),
         .package(name: "Codextended", url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
         .package(name: "ShellOut", url: "https://github.com/johnsundell/shellout.git", from: "2.3.0"),
-        .package(name: "Sweep", url: "https://github.com/johnsundell/sweep.git", from: "0.4.0")
+        .package(name: "Sweep", url: "https://github.com/johnsundell/sweep.git", from: "0.4.0"),
+        .package(name: "StaticServer", url: "https://github.com/Mastermakrela/Static-Server", from: "0.0.4")
     ],
     targets: [
         .target(
@@ -35,7 +36,7 @@ let package = Package(
         ),
         .target(
             name: "PublishCLICore",
-            dependencies: ["Publish"]
+            dependencies: ["Publish", "StaticServer"]
         ),
         .testTarget(
             name: "PublishTests",

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(name: "Codextended", url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
         .package(name: "ShellOut", url: "https://github.com/johnsundell/shellout.git", from: "2.3.0"),
         .package(name: "Sweep", url: "https://github.com/johnsundell/sweep.git", from: "0.4.0"),
-        .package(name: "StaticServer", url: "https://github.com/Mastermakrela/Static-Server", from: "0.0.4")
+        .package(name: "StaticServer", url: "https://github.com/Mastermakrela/Static-Server", from: "0.0.5")
     ],
     targets: [
         .target(

--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -29,8 +29,10 @@ internal struct WebsiteRunner {
             """)
 
             try server.start()
-        } catch {
+        } catch let error as ServerError {
             outputServerError(error)
+        } catch {
+            outputError(error)
         }
     }
 }
@@ -68,7 +70,7 @@ private extension WebsiteRunner {
         fputs("\n❌ Failed to start local web server:\n\(message)\n", stderr)
     }
 
-    func outputServerError(_ error: Error) {
+    func outputError(_ error: Error) {
         fputs("\n❌ Failed to start local web server:\n\(error.localizedDescription)\n", stderr)
     }
 }


### PR DESCRIPTION
# Replace python localhost server with Swift NIO one

## Advantages:
1. Publish CLI doesn't have to spawn python process
2. Publish CLI isn't dependent on python being available
3. Localhost server can be run through Xcode (earlier `readLine()` line didn't play nice with Xcode's console, see image below)

![img1](https://user-images.githubusercontent.com/28502567/100939074-fcedb200-34f5-11eb-8d61-be995296e95e.png)

4. We get solution to "ctrl+c to stop"(#82) for free

## Contribution
In this pull request I've updated the `/Sources/PublishCLICore/WebsiteRunner.swift` file to use Swift NIO server.
And I've written "How To" article about running through Xcode.

### _Disclaimers_
It's my first time contributing, so please correct me if I made something wrong 😅

_StaticServer Package is small, why didn't you integrate it directly into Publish?_
I know but for sake of modularity I thought it makes more sense to put this functionality into a separate Package.


---
Thank you for reading :)
Best Regards,
Christoph