### PR TITLE
Added serve CLI utility

### DIFF
--- a/Sources/PublishCLICore/CLI.swift
+++ b/Sources/PublishCLICore/CLI.swift
@@ -46,6 +46,10 @@ public struct CLI {
             let portNumber = extractPortNumber(from: arguments)
             let runner = WebsiteRunner(folder: folder, portNumber: portNumber)
             try runner.run()
+        case "serve":
+            let portNumber = extractPortNumber(from: arguments)
+            let server = WebsiteServer(folder: folder, portNumber: portNumber)
+            try server.serve()
         default:
             outputHelpText()
         }

--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -15,77 +15,8 @@ internal struct WebsiteRunner {
     func run() throws {
         let generator = WebsiteGenerator(folder: folder)
         try generator.generate()
-
-        let outputFolder = try resolveOutputFolder()
-
-        let serverQueue = DispatchQueue(label: "Publish.WebServer")
-        let serverProcess = Process()
-
-        print("""
-        🌍 Starting web server at http://localhost:\(portNumber)
-
-        Press ENTER to stop the server and exit
-        """)
-
-        serverQueue.async {
-            do {
-                _ = try shellOut(
-                    to: "python -m \(self.resolvePythonHTTPServerCommand()) \(self.portNumber)",
-                    at: outputFolder.path,
-                    process: serverProcess
-                )
-            } catch let error as ShellOutError {
-                self.outputServerErrorMessage(error.message)
-            } catch {
-                self.outputServerErrorMessage(error.localizedDescription)
-            }
-
-            serverProcess.terminate()
-            exit(1)
-        }
-
-        _ = readLine()
-        serverProcess.terminate()
-    }
-}
-
-private extension WebsiteRunner {
-    func resolveOutputFolder() throws -> Folder {
-        do { return try folder.subfolder(named: "Output") }
-        catch { throw CLIError.outputFolderNotFound }
-    }
-
-    func resolvePythonHTTPServerCommand() -> String {
-        if resolveSystemPythonMajorVersionNumber() >= 3 {
-            return "http.server"
-        } else {
-            return "SimpleHTTPServer"
-        }
-    }
-
-    func resolveSystemPythonMajorVersionNumber() -> Int {
-        // Expected output: `Python X.X.X`
-        let pythonVersionString = try? shellOut(to: "python --version")
-        let fullVersionNumber = pythonVersionString?.split(separator: " ").last
-        let majorVersionNumber = fullVersionNumber?.first
-        return majorVersionNumber?.wholeNumberValue ?? 2
-    }
-
-    func outputServerErrorMessage(_ message: String) {
-        var message = message
-
-        if message.hasPrefix("Traceback"),
-           message.contains("Address already in use") {
-            message = """
-            A localhost server is already running on port number \(portNumber).
-            - Perhaps another 'publish run' session is running?
-            - Publish uses Python's simple HTTP server, so to find any
-              running processes, you can use either Activity Monitor
-              or the 'ps' command and search for 'python'. You can then
-              terminate any previous process in order to start a new one.
-            """
-        }
-
-        fputs("\n❌ Failed to start local web server:\n\(message)\n", stderr)
+        
+        let server = WebsiteServer.init(folder: folder, portNumber: portNumber)
+        try server.serve()
     }
 }

--- a/Sources/PublishCLICore/WebsiteServer.swift
+++ b/Sources/PublishCLICore/WebsiteServer.swift
@@ -1,0 +1,89 @@
+//
+//  File.swift
+//  
+//
+//  Created by Tanishq Kancharla on 12/20/20.
+//
+
+import Foundation
+import Files
+import ShellOut
+
+internal struct WebsiteServer {
+    let folder: Folder
+    var portNumber: Int
+
+    func serve() throws {
+        let outputFolder = try resolveOutputFolder()
+
+        let serverQueue = DispatchQueue(label: "Publish.WebServer")
+        let serverProcess = Process()
+
+        print("""
+        🌍 Starting web server at http://localhost:\(portNumber)
+
+        Press ENTER to stop the server and exit
+        """)
+
+        serverQueue.async {
+            do {
+                _ = try shellOut(
+                    to: "python -m \(self.resolvePythonHTTPServerCommand()) \(self.portNumber)",
+                    at: outputFolder.path,
+                    process: serverProcess
+                )
+            } catch let error as ShellOutError {
+                self.outputServerErrorMessage(error.message)
+            } catch {
+                self.outputServerErrorMessage(error.localizedDescription)
+            }
+
+            serverProcess.terminate()
+            exit(1)
+        }
+
+        _ = readLine()
+        serverProcess.terminate()
+    }
+}
+
+private extension WebsiteServer {
+    func resolveOutputFolder() throws -> Folder {
+        do { return try folder.subfolder(named: "Output") }
+        catch { throw CLIError.outputFolderNotFound }
+    }
+
+    func resolvePythonHTTPServerCommand() -> String {
+        if resolveSystemPythonMajorVersionNumber() >= 3 {
+            return "http.server"
+        } else {
+            return "SimpleHTTPServer"
+        }
+    }
+
+    func resolveSystemPythonMajorVersionNumber() -> Int {
+        // Expected output: `Python X.X.X`
+        let pythonVersionString = try? shellOut(to: "python --version")
+        let fullVersionNumber = pythonVersionString?.split(separator: " ").last
+        let majorVersionNumber = fullVersionNumber?.first
+        return majorVersionNumber?.wholeNumberValue ?? 2
+    }
+
+    func outputServerErrorMessage(_ message: String) {
+        var message = message
+
+        if message.hasPrefix("Traceback"),
+           message.contains("Address already in use") {
+            message = """
+            A localhost server is already running on port number \(portNumber).
+            - Perhaps another 'publish run' session is running?
+            - Publish uses Python's simple HTTP server, so to find any
+              running processes, you can use either Activity Monitor
+              or the 'ps' command and search for 'python'. You can then
+              terminate any previous process in order to start a new one.
+            """
+        }
+
+        fputs("\n❌ Failed to start local web server:\n\(message)\n", stderr)
+    }
+}


### PR DESCRIPTION
Hello! As part of my website creation, I needed to do some post processing after Publish generates its html files. However, I also wanted to use Publish's built in server (`publish run`). I couldn't do this since `run` regenerates the website, deleting all of the post processing I had performed. Therefore, I added a "serve" CLI utility that just serves the code in the output directory without regenerating it. Therefore, my workflow would look like

```
publish generate
*postprocess*
publish serve
```

I moved all the `WebsiteRunner` class into `WebsiteServer` so now `WebsiteRunner` effectively just calls `WebsiteGenerator` then `WebsiteServer`.
