### PR TITLE
Generates AMP version of any location.

### DIFF
--- a/Sources/Publish/API/AMPHTMLConfiguration.swift
+++ b/Sources/Publish/API/AMPHTMLConfiguration.swift
@@ -4,19 +4,24 @@
 *  MIT license, see LICENSE file for details
 */
 
-/// Configuration type used to customize how a website's
-/// AMP pages gets rendered. To use a default implementation,
+/// Configuration type used to customize which and where
+/// AMP pages are generated. To use a default implementation,
 /// use `AMPHTMLConfiguration.default`.
 public struct AMPHTMLConfiguration {
-    /// The path that will be appended to a resources to obtain the path of the AMP version.
-    public var suffixPath: Path
-
+    /// A closure that given a location, provides the path to the AMP version of that location.
+    ///
+    /// You can filter over the type of location (or a specific location) to return `nil`, which means that no AMP
+    /// version of that location is generated.
+    public var pathForLocation: (Location) -> Path?
+    
     /// Initialize a new configuration instance.
-    /// - Parameter suffixPath: The path that will be appended to a resources to obtain the path of the AMP version.
+    /// - Parameter pathForLocation: A closure that given a location, provides the path to the AMP version of that location.
     public init(
-        suffixPath: Path = .defaultForAMPHTML
+        pathForLocation: @escaping (Location) -> Path? = { location in
+            return Path("\(location.path)/\(Path.defaultForAMPHTML).html")
+        }
     ) {
-        self.suffixPath = suffixPath
+        self.pathForLocation = pathForLocation
     }
 }
 

--- a/Sources/Publish/API/AMPHTMLConfiguration.swift
+++ b/Sources/Publish/API/AMPHTMLConfiguration.swift
@@ -1,0 +1,26 @@
+/**
+*  Publish
+*  Copyright (c) John Sundell 2020
+*  MIT license, see LICENSE file for details
+*/
+
+/// Configuration type used to customize how a website's
+/// AMP pages gets rendered. To use a default implementation,
+/// use `AMPHTMLConfiguration.default`.
+public struct AMPHTMLConfiguration {
+    /// The path that will be appended to a resources to obtain the path of the AMP version.
+    public var suffixPath: Path
+
+    /// Initialize a new configuration instance.
+    /// - Parameter suffixPath: The path that will be appended to a resources to obtain the path of the AMP version.
+    public init(
+        suffixPath: Path = .defaultForAMPHTML
+    ) {
+        self.suffixPath = suffixPath
+    }
+}
+
+public extension AMPHTMLConfiguration {
+    /// Create a default AMP HTML configuration implementation.
+    static var `default`: Self { .init() }
+}

--- a/Sources/Publish/API/HTMLFactory.swift
+++ b/Sources/Publish/API/HTMLFactory.swift
@@ -51,4 +51,30 @@ public protocol HTMLFactory {
     /// - parameter context: The current publishing context.
     func makeTagDetailsHTML(for page: TagDetailsPage,
                             context: PublishingContext<Site>) throws -> HTML?
+    
+    // MARK: - AMP versions
+    
+    /// Create the AMP version of the HTML to use for the website's main index page.
+    /// - parameter index: The index page to generate HTML for.
+    /// - parameter context: The current publishing context.
+    func makeAMPIndexHTML(for index: Index,
+                          context: PublishingContext<Site>) throws -> HTML
+    
+    /// Create the AMP version of the HTML to use for the index page of a section.
+    /// - parameter section: The section to generate HTML for.
+    /// - parameter context: The current publishing context.
+    func makeAMPSectionHTML(for section: Section<Site>,
+                            context: PublishingContext<Site>) throws -> HTML
+    
+    /// Create the AMP version of the HTML to use for an item.
+    /// - parameter item: The item to generate HTML for.
+    /// - parameter context: The current publishing context.
+    func makeAMPItemHTML(for item: Item<Site>,
+                         context: PublishingContext<Site>) throws -> HTML
+    
+    /// Create the AMP version of the HTML to use for a page.
+    /// - parameter page: The page to generate HTML for.
+    /// - parameter context: The current publishing context.
+    func makeAMPPageHTML(for page: Page,
+                         context: PublishingContext<Site>) throws -> HTML
 }

--- a/Sources/Publish/API/Path.swift
+++ b/Sources/Publish/API/Path.swift
@@ -23,6 +23,8 @@ public extension Path {
     static var defaultForTagHTML: Path { "tags" }
     /// The default path used for website favicons.
     static var defaultForFavicon: Path { "images/favicon.png" }
+    /// The default path used when generating HTML for AMP version of resources.
+    static var defaultForAMPHTML: Path { "amp" }
 
     /// Convert this path into an absolute string, which can be used to
     /// refer to locations and resources based on the root of a website.

--- a/Sources/Publish/API/Theme+Foundation.swift
+++ b/Sources/Publish/API/Theme+Foundation.swift
@@ -154,6 +154,32 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
             )
         )
     }
+    
+    // MARK: - AMP versions
+    
+    func makeAMPIndexHTML(for index: Index,
+                          context: PublishingContext<Site>) throws -> HTML {
+        // TODO adapt to AMP
+        return try makeIndexHTML(for: index, context: context)
+    }
+    
+    func makeAMPSectionHTML(for section: Section<Site>,
+                            context: PublishingContext<Site>) throws -> HTML {
+        // TODO adapt to AMP
+        return try makeSectionHTML(for: section, context: context)
+    }
+    
+    func makeAMPItemHTML(for item: Item<Site>,
+                         context: PublishingContext<Site>) throws -> HTML {
+        // TODO adapt to AMP
+        return try makeItemHTML(for: item, context: context)
+    }
+    
+    func makeAMPPageHTML(for page: Page,
+                      context: PublishingContext<Site>) throws -> HTML {
+        // TODO adapt to AMP
+        return try makePageHTML(for: page, context: context)
+    }
 }
 
 private extension Node where Context == HTML.BodyContext {

--- a/Sources/Publish/API/Theme.swift
+++ b/Sources/Publish/API/Theme.swift
@@ -17,6 +17,13 @@ public struct Theme<Site: Website> {
     internal let makePageHTML: (Page, PublishingContext<Site>) throws -> HTML
     internal let makeTagListHTML: (TagListPage, PublishingContext<Site>) throws -> HTML?
     internal let makeTagDetailsHTML: (TagDetailsPage, PublishingContext<Site>) throws -> HTML?
+    
+    // MARK: AMP versions
+    internal let makeAMPIndexHTML: (Index, PublishingContext<Site>) throws -> HTML
+    internal let makeAMPSectionHTML: (Section<Site>, PublishingContext<Site>) throws -> HTML
+    internal let makeAMPItemHTML: (Item<Site>, PublishingContext<Site>) throws -> HTML
+    internal let makeAMPPageHTML: (Page, PublishingContext<Site>) throws -> HTML
+    
     internal let resourcePaths: Set<Path>
     internal let creationPath: Path
 
@@ -38,6 +45,10 @@ public struct Theme<Site: Website> {
         makePageHTML = factory.makePageHTML
         makeTagListHTML = factory.makeTagListHTML
         makeTagDetailsHTML = factory.makeTagDetailsHTML
+        makeAMPIndexHTML = factory.makeAMPIndexHTML
+        makeAMPSectionHTML = factory.makeAMPSectionHTML
+        makeAMPItemHTML = factory.makeAMPItemHTML
+        makeAMPPageHTML = factory.makeAMPPageHTML
         resourcePaths = resources
         creationPath = Path("\(file)")
     }

--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -40,6 +40,9 @@ public protocol Website {
     /// The configuration to use when generating tag HTML for the website.
     /// If this is `nil`, then no tag HTML will be generated.
     var tagHTMLConfig: TagHTMLConfiguration? { get }
+    /// The configuration to use when generating AMP HTML for the website.
+    /// If this is `nil`, then no AMP HTML will be generated.
+    var ampHTMLConfig: AMPHTMLConfiguration? { get }
 }
 
 // MARK: - Defaults

--- a/Sources/Publish/Internal/HTMLGenerator.swift
+++ b/Sources/Publish/Internal/HTMLGenerator.swift
@@ -19,6 +19,7 @@ internal struct HTMLGenerator<Site: Website> {
         try generateSectionHTML()
         try generatePageHTML()
         try generateTagHTMLIfNeeded()
+        try generateAMPHTMLIfNeeded()
     }
 }
 
@@ -120,6 +121,15 @@ private extension HTMLGenerator {
                 fileMode: fileMode
             )
         }
+    }
+    
+    /// Genetares the AMP version of the website, only for those resources specified by
+    /// `context.site.ampHTMLConfig`.
+    func generateAMPHTMLIfNeeded() throws {
+        guard let config = context.site.ampHTMLConfig else {
+            return
+        }
+        // TODO generate AMP pages
     }
 
     func outputHTML<T: Location>(


### PR DESCRIPTION
I added to my own website the [AMP](https://amp.dev/documentation/guides-and-tutorials/start/create/?format=websites) version of all items.

I added a `AMPHTMLConfiguration` (similar to `TagHTMLConfiguration`), where you can declare which locations will have an AMP version. For instance

```swift
// Generate AMP pages, only for items.
var ampHTMLConfig: AMPHTMLConfiguration? = AMPHTMLConfiguration { location in
    if location is Item<YourWebsite> {
        return Path("\(location.path)/\(Path.defaultForAMPHTML).html")
    }
    return nil
}
```

Then in your implementation of `Theme`, you need to implement a new HTML generator for each type of location. If that specific location type (index, page, section, item, tag, and tag detail) is excluded by `AMPHTMLConfiguration`, then it does not matter what the related HTML generator will return.

The current version is not finished, but it is enough for my use case. If the community is interested in it (and if the way I implemented it is the preferred way), then I can finish it and complete the pull request. Given that this involves internal 
changes (mainly `HTMLGenerator.html`), I will wait for comments from the maintainers to go on with it.

Still TODO:

- [ ] Add generation of tag pages (not yet implemented); 
- [ ] Give basic implementation of the new HTML generators in `Theme+Foundation.swift`;
- [ ] Update the existing HTML generator in `Theme+Foundation.swift` and `PlotComponents.swift` to add the AMP rel link to the head section, only if the AMP version is generated.
- [ ] Tests
- [ ] Update README