### PR TITLE
Adopt AnyDateFormatter from Codextended

### DIFF
--- a/Documentation/HowTo/using-a-custom-date-formatter.md
+++ b/Documentation/HowTo/using-a-custom-date-formatter.md
@@ -12,3 +12,14 @@ try MyWebsite.publish(using: [
     }
 ])
 ```
+
+You can also use `ISO8601DateFormatter`.
+
+```swift
+try MyWebsite.publish(using: [
+    ...
+    .step(named: "Use ISO8601DateFormatter") { context in
+        context.dateFormatter = ISO8601DateFormatter()
+    }
+])
+```

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "Codextended",
-        "repositoryURL": "https://github.com/johnsundell/codextended.git",
+        "repositoryURL": "https://github.com/addisonwebb/codextended.git",
         "state": {
-          "branch": null,
-          "revision": "8d7c46dfc9c55240870cf5561d6cefa41e3d7105",
-          "version": "0.3.0"
+          "branch": "update-any-date-formatter",
+          "revision": "69f133ad154a1b1eadbdb898b755788e987ac1c9",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(name: "Ink", url: "https://github.com/johnsundell/ink.git", from: "0.2.0"),
         .package(name: "Plot", url: "https://github.com/johnsundell/plot.git", from: "0.4.0"),
         .package(name: "Files", url: "https://github.com/johnsundell/files.git", from: "4.0.0"),
-        .package(name: "Codextended", url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
+        .package(name: "Codextended", url: "https://github.com/addisonwebb/codextended.git", .branch("update-any-date-formatter")),
         .package(name: "ShellOut", url: "https://github.com/johnsundell/shellout.git", from: "2.3.0"),
         .package(name: "Sweep", url: "https://github.com/johnsundell/sweep.git", from: "0.4.0")
     ],

--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -22,7 +22,7 @@ public struct PublishingContext<Site: Website> {
     public var markdownParser = MarkdownParser()
     /// The date formatter that this publishing session is using when parsing
     /// dates from Markdown files.
-    public var dateFormatter: DateFormatter
+    public var dateFormatter: AnyDateFormatter
     /// A representation of the website's main index page.
     public var index = Index()
     /// The sections that the website contains.

--- a/Sources/Publish/Internal/MarkdownContentFactory.swift
+++ b/Sources/Publish/Internal/MarkdownContentFactory.swift
@@ -11,7 +11,7 @@ import Codextended
 
 internal struct MarkdownContentFactory<Site: Website> {
     let parser: MarkdownParser
-    let dateFormatter: DateFormatter
+    let dateFormatter: AnyDateFormatter
 
     func makeContent(fromFile file: File) throws -> Content {
         let markdown = try parser.parse(file.readAsString())

--- a/Sources/Publish/Internal/MarkdownMetadataDecoder.swift
+++ b/Sources/Publish/Internal/MarkdownMetadataDecoder.swift
@@ -5,18 +5,19 @@
 */
 
 import Foundation
+import Codextended
 
 internal final class MarkdownMetadataDecoder: Decoder {
     var userInfo: [CodingUserInfoKey : Any] { [:] }
     let codingPath: [CodingKey]
 
     private let metadata: [String : String]
-    private let dateFormatter: DateFormatter
+    private let dateFormatter: AnyDateFormatter
     private lazy var keyedContainers = [ObjectIdentifier : Any]()
 
     init(metadata: [String : String],
          codingPath: [CodingKey] = [],
-         dateFormatter: DateFormatter) {
+         dateFormatter: AnyDateFormatter) {
         self.metadata = metadata
         self.codingPath = codingPath
         self.dateFormatter = dateFormatter
@@ -73,11 +74,11 @@ private extension MarkdownMetadataDecoder {
         let keys: KeyMap<Key>
         let codingPath: [CodingKey]
         let prefix: String
-        let dateFormatter: DateFormatter
+        let dateFormatter: AnyDateFormatter
 
         init(metadata: [String : String],
              codingPath: [CodingKey],
-             dateFormatter: DateFormatter) {
+             dateFormatter: AnyDateFormatter) {
             self.metadata = metadata
             self.keys = KeyMap(raw: metadata.keys, codingPath: codingPath)
             self.codingPath = codingPath
@@ -622,7 +623,7 @@ private extension Date {
     static func decode(from string: String,
                        forKey key: CodingKey?,
                        at codingPath: [CodingKey],
-                       formatter: DateFormatter) throws -> Self {
+                       formatter: AnyDateFormatter) throws -> Self {
         guard let date = formatter.date(from: string) else {
             let formatDescription = formatter.dateFormat.map {
                 " Expected format: \($0)."


### PR DESCRIPTION
**This PR is dependent on [Codextended PR #15](https://github.com/JohnSundell/Codextended/pull/15).** This draft PR will be updated to point to the new version of Codextended once that PR is merged and a new release is tagged.

This PR aims to solve the same issue as #77 and was inspired by @dpfannenstiel.

### Why
As a website developer, I would like to use dates formatted according to the ISO 8601 standard.

### Problem
Currently, a developer may specify a custom date formatter that is a `DateFormatter`. This solution prevents the use of `ISO8601DateFormatter` since it inherits directly from `Formatter` instead of `DateFormatter`.

### Solution
This change adopts `AnyDateFormatter` from Codextended. This allows you to use ether `DateFormatter` or `ISO8601DateFormatter` as the `PublishingContext.dateFormatter`.

```swift
.step(named: "Use ISO 8601 Date Formatter") { context in
    context.dateFormatter = ISO8601DateFormatter()
}
```

This change should be the minimal set of changes required to support `ISO8601DateFormatter` as an option for developers. It should not introduce any breaking changes for current Publish users.