### PR TITLE
Adopt Plot's new Component-based API

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/johnsundell/plot.git",
         "state": {
           "branch": null,
-          "revision": "61e828949ca6f84071bde65c8fc046cf74b7d1a2",
-          "version": "0.8.0"
+          "revision": "80612b34252188edbef280e5375e2fc5249ac770",
+          "version": "0.9.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Ink", url: "https://github.com/johnsundell/ink.git", from: "0.2.0"),
-        .package(name: "Plot", url: "https://github.com/johnsundell/plot.git", from: "0.4.0"),
+        .package(name: "Plot", url: "https://github.com/johnsundell/plot.git", from: "0.9.0"),
         .package(name: "Files", url: "https://github.com/johnsundell/files.git", from: "4.0.0"),
         .package(name: "Codextended", url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
         .package(name: "ShellOut", url: "https://github.com/johnsundell/shellout.git", from: "2.3.0"),

--- a/Sources/Publish/API/Content.swift
+++ b/Sources/Publish/API/Content.swift
@@ -47,19 +47,37 @@ public struct Content: Hashable, ContentProtocol {
 }
 
 public extension Content {
+    /// Type that represents the main renderable body of a piece of content.
     struct Body: Hashable {
+        /// The content's renderable HTML.
         public var html: String
+        /// A node that can be used to embed the content in a Plot hierarchy.
         public var node: Node<HTML.BodyContext> { .raw(html) }
+        /// Whether this value doesn't contain any content.
         public var isEmpty: Bool { html.isEmpty }
 
+        /// Initialize an instance with a ready-made HTML string.
+        /// - parameter html: The content HTML that the instance should cointain.
         public init(html: String) {
             self.html = html
         }
 
+        /// Initialize an instance with a Plot `Node`.
+        /// - parameter node: The node to render. See `Node` for more information.
+        /// - parameter indentation: Any indentation to apply when rendering the node.
         public init(node: Node<HTML.BodyContext>,
                     indentation: Indentation.Kind? = nil) {
             html = node.render(indentedBy: indentation)
         }
+
+        /// Initialize an instance using Plot's `Component` API.
+        /// - parameter indentation: Any indentation to apply when rendering the components.
+        /// - parameter components: The components that should make up this instance's content.
+        public init(indentation: Indentation.Kind? = nil,
+                    @ComponentBuilder components: () -> Component) {
+           self.init(node: .component(components()),
+                     indentation: indentation)
+       }
     }
 }
 
@@ -67,4 +85,8 @@ extension Content.Body: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         self.init(html: value)
     }
+}
+
+extension Content.Body: Component {
+    public var body: Component { node }
 }

--- a/Sources/Publish/API/PlotEnvironmentKeys.swift
+++ b/Sources/Publish/API/PlotEnvironmentKeys.swift
@@ -1,0 +1,8 @@
+import Plot
+import Ink
+
+public extension EnvironmentKey where Value == MarkdownParser {
+    /// Environment key that can be used to pass what `MarkdownParser` that
+    /// should be used when rendering `Markdown` components.
+    static var markdownParser: Self { .init(defaultValue: .init()) }
+}

--- a/Sources/Publish/API/PlotModifiers.swift
+++ b/Sources/Publish/API/PlotModifiers.swift
@@ -1,0 +1,13 @@
+import Ink
+import Plot
+
+public extension Component {
+    /// Assign what `MarkdownParser` to use when rendering `Markdown` components
+    /// within this component hierarchy. This value is placed in the environment,
+    /// and is thus inherited by all child components. Note that this modifier
+    /// does not affect nodes rendered using the `.markdown` API.
+    /// - parameter parser: The parser to assign.
+    func markdownParser(_ parser: MarkdownParser) -> Component {
+        environmentValue(parser, key: .markdownParser)
+    }
+}

--- a/Sources/Publish/API/Theme+Foundation.swift
+++ b/Sources/Publish/API/Theme+Foundation.swift
@@ -23,25 +23,23 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
         HTML(
             .lang(context.site.language),
             .head(for: index, on: context.site),
-            .body(
-                .header(for: context, selectedSection: nil),
-                .wrapper(
-                    .h1(.text(index.title)),
-                    .p(
-                        .class("description"),
-                        .text(context.site.description)
-                    ),
-                    .h2("Latest content"),
-                    .itemList(
-                        for: context.allItems(
+            .body {
+                SiteHeader(context: context, selectedSelectionID: nil)
+                Wrapper {
+                    H1(index.title)
+                    Paragraph(context.site.description)
+                        .class("description")
+                    H2("Latest content")
+                    ItemList(
+                        items: context.allItems(
                             sortedBy: \.date,
                             order: .descending
                         ),
-                        on: context.site
+                        site: context.site
                     )
-                ),
-                .footer(for: context.site)
-            )
+                }
+                SiteFooter()
+            }
         )
     }
 
@@ -50,14 +48,14 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
         HTML(
             .lang(context.site.language),
             .head(for: section, on: context.site),
-            .body(
-                .header(for: context, selectedSection: section.id),
-                .wrapper(
-                    .h1(.text(section.title)),
-                    .itemList(for: section.items, on: context.site)
-                ),
-                .footer(for: context.site)
-            )
+            .body {
+                SiteHeader(context: context, selectedSelectionID: section.id)
+                Wrapper {
+                    H1(section.title)
+                    ItemList(items: section.items, site: context.site)
+                }
+                SiteFooter()
+            }
         )
     }
 
@@ -68,18 +66,17 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
             .head(for: item, on: context.site),
             .body(
                 .class("item-page"),
-                .header(for: context, selectedSection: item.sectionID),
-                .wrapper(
-                    .article(
-                        .div(
-                            .class("content"),
-                            .contentBody(item.body)
-                        ),
-                        .span("Tagged with: "),
-                        .tagList(for: item, on: context.site)
-                    )
-                ),
-                .footer(for: context.site)
+                .components {
+                    SiteHeader(context: context, selectedSelectionID: item.sectionID)
+                    Wrapper {
+                        Article {
+                            Div(item.content.body).class("content")
+                            Span("Tagged with: ")
+                            ItemTagList(item: item, site: context.site)
+                        }
+                    }
+                    SiteFooter()
+                }
             )
         )
     }
@@ -89,11 +86,11 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
         HTML(
             .lang(context.site.language),
             .head(for: page, on: context.site),
-            .body(
-                .header(for: context, selectedSection: nil),
-                .wrapper(.contentBody(page.body)),
-                .footer(for: context.site)
-            )
+            .body {
+                SiteHeader(context: context, selectedSelectionID: nil)
+                Wrapper(page.body)
+                SiteFooter()
+            }
         )
     }
 
@@ -102,25 +99,22 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
         HTML(
             .lang(context.site.language),
             .head(for: page, on: context.site),
-            .body(
-                .header(for: context, selectedSection: nil),
-                .wrapper(
-                    .h1("Browse all tags"),
-                    .ul(
-                        .class("all-tags"),
-                        .forEach(page.tags.sorted()) { tag in
-                            .li(
-                                .class("tag"),
-                                .a(
-                                    .href(context.site.path(for: tag)),
-                                    .text(tag.string)
-                                )
+            .body {
+                SiteHeader(context: context, selectedSelectionID: nil)
+                Wrapper {
+                    H1("Browse all tags")
+                    List(page.tags.sorted()) { tag in
+                        ListItem {
+                            Link(tag.string,
+                                 url: context.site.path(for: tag).absoluteString
                             )
                         }
-                    )
-                ),
-                .footer(for: context.site)
-            )
+                        .class("tag")
+                    }
+                    .class("all-tags")
+                }
+                SiteFooter()
+            }
         )
     }
 
@@ -129,100 +123,111 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
         HTML(
             .lang(context.site.language),
             .head(for: page, on: context.site),
-            .body(
-                .header(for: context, selectedSection: nil),
-                .wrapper(
-                    .h1(
-                        "Tagged with ",
-                        .span(.class("tag"), .text(page.tag.string))
-                    ),
-                    .a(
-                        .class("browse-all"),
-                        .text("Browse all tags"),
-                        .href(context.site.tagListPath)
-                    ),
-                    .itemList(
-                        for: context.items(
+            .body {
+                SiteHeader(context: context, selectedSelectionID: nil)
+                Wrapper {
+                    H1 {
+                        Text("Tagged with ")
+                        Span(page.tag.string).class("tag")
+                    }
+
+                    Link("Browse all tags",
+                        url: context.site.tagListPath.absoluteString
+                    )
+                    .class("browse-all")
+
+                    ItemList(
+                        items: context.items(
                             taggedWith: page.tag,
                             sortedBy: \.date,
                             order: .descending
                         ),
-                        on: context.site
+                        site: context.site
                     )
-                ),
-                .footer(for: context.site)
-            )
+                }
+                SiteFooter()
+            }
         )
     }
 }
 
-private extension Node where Context == HTML.BodyContext {
-    static func wrapper(_ nodes: Node...) -> Node {
-        .div(.class("wrapper"), .group(nodes))
+private struct Wrapper: ComponentContainer {
+    @ComponentBuilder var content: ContentProvider
+
+    var body: Component {
+        Div(content: content).class("wrapper")
     }
+}
 
-    static func header<T: Website>(
-        for context: PublishingContext<T>,
-        selectedSection: T.SectionID?
-    ) -> Node {
-        let sectionIDs = T.SectionID.allCases
+private struct SiteHeader<Site: Website>: Component {
+    var context: PublishingContext<Site>
+    var selectedSelectionID: Site.SectionID?
 
-        return .header(
-            .wrapper(
-                .a(.class("site-name"), .href("/"), .text(context.site.name)),
-                .if(sectionIDs.count > 1,
-                    .nav(
-                        .ul(.forEach(sectionIDs) { section in
-                            .li(.a(
-                                .class(section == selectedSection ? "selected" : ""),
-                                .href(context.sections[section].path),
-                                .text(context.sections[section].title)
-                            ))
-                        })
-                    )
-                )
-            )
-        )
-    }
+    var body: Component {
+        Header {
+            Wrapper {
+                Link(context.site.name, url: "/")
+                    .class("site-name")
 
-    static func itemList<T: Website>(for items: [Item<T>], on site: T) -> Node {
-        return .ul(
-            .class("item-list"),
-            .forEach(items) { item in
-                .li(.article(
-                    .h1(.a(
-                        .href(item.path),
-                        .text(item.title)
-                    )),
-                    .tagList(for: item, on: site),
-                    .p(.text(item.description))
-                ))
+                if Site.SectionID.allCases.count > 1 {
+                    navigation
+                }
             }
-        )
+        }
     }
 
-    static func tagList<T: Website>(for item: Item<T>, on site: T) -> Node {
-        return .ul(.class("tag-list"), .forEach(item.tags) { tag in
-            .li(.a(
-                .href(site.path(for: tag)),
-                .text(tag.string)
-            ))
-        })
-    }
+    private var navigation: Component {
+        Navigation {
+            List(Site.SectionID.allCases) { sectionID in
+                let section = context.sections[sectionID]
 
-    static func footer<T: Website>(for site: T) -> Node {
-        return .footer(
-            .p(
-                .text("Generated using "),
-                .a(
-                    .text("Publish"),
-                    .href("https://github.com/johnsundell/publish")
+                return Link(section.title,
+                    url: section.path.absoluteString
                 )
-            ),
-            .p(.a(
-                .text("RSS feed"),
-                .href("/feed.rss")
-            ))
-        )
+                .class(sectionID == selectedSelectionID ? "selected" : "")
+            }
+        }
+    }
+}
+
+private struct ItemList<Site: Website>: Component {
+    var items: [Item<Site>]
+    var site: Site
+
+    var body: Component {
+        List(items) { item in
+            Article {
+                H1(Link(item.title, url: item.path.absoluteString))
+                ItemTagList(item: item, site: site)
+                Paragraph(item.description)
+            }
+        }
+        .class("item-list")
+    }
+}
+
+private struct ItemTagList<Site: Website>: Component {
+    var item: Item<Site>
+    var site: Site
+
+    var body: Component {
+        List(item.tags) { tag in
+            Link(tag.string, url: site.path(for: tag).absoluteString)
+        }
+        .class("tag-list")
+    }
+}
+
+private struct SiteFooter: Component {
+    var body: Component {
+        Footer {
+            Paragraph {
+                Text("Generated using ")
+                Link("Publish", url: "https://github.com/johnsundell/publish")
+            }
+            Paragraph {
+                Link("RSS feed", url: "/feed.rss")
+            }
+        }
     }
 }

--- a/Sources/Publish/Internal/MarkdownContentFactory.swift
+++ b/Sources/Publish/Internal/MarkdownContentFactory.swift
@@ -50,14 +50,14 @@ internal struct MarkdownContentFactory<Site: Website> {
 }
 
 private extension MarkdownContentFactory {
-    func makeMetadataDecoder(for markdown: Markdown) -> MarkdownMetadataDecoder {
+    func makeMetadataDecoder(for markdown: Ink.Markdown) -> MarkdownMetadataDecoder {
         MarkdownMetadataDecoder(
             metadata: markdown.metadata,
             dateFormatter: dateFormatter
         )
     }
 
-    func makeContent(fromMarkdown markdown: Markdown,
+    func makeContent(fromMarkdown markdown: Ink.Markdown,
                      file: File,
                      decoder: MarkdownMetadataDecoder) throws -> Content {
         let title = try decoder.decodeIfPresent("title", as: String.self)

--- a/Tests/PublishTests/Tests/PlotComponentTests.swift
+++ b/Tests/PublishTests/Tests/PlotComponentTests.swift
@@ -7,6 +7,7 @@
 import XCTest
 import Publish
 import Plot
+import Ink
 
 final class PlotComponentTests: PublishTestCase {
     func testStylesheetPaths() {
@@ -60,10 +61,10 @@ final class PlotComponentTests: PublishTestCase {
         let html = Node.videoPlayer(for: video).render()
 
         XCTAssertEqual(html, """
-        <iframe frameborder="0"\
-         allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"\
+        <iframe src="https://www.youtube-nocookie.com/embed/123"\
+         frameborder="0"\
          allowfullscreen="true"\
-         src="https://www.youtube-nocookie.com/embed/123"\
+         allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"\
         ></iframe>
         """)
     }
@@ -73,11 +74,35 @@ final class PlotComponentTests: PublishTestCase {
         let html = Node.videoPlayer(for: video).render()
 
         XCTAssertEqual(html, """
-        <iframe frameborder="0"\
-         allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"\
+        <iframe src="https://player.vimeo.com/video/123"\
+         frameborder="0"\
          allowfullscreen="true"\
-         src="https://player.vimeo.com/video/123"\
+         allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"\
         ></iframe>
+        """)
+    }
+
+    func testRenderingMarkdownComponent() {
+        let customParser = MarkdownParser(modifiers: [
+            Modifier(target: .links) { html, _ in
+                return "<b>\(html)</b>"
+            }
+        ])
+
+        let html = Div {
+            Markdown("[First](/first)")
+            Div {
+                Markdown("[Second](/second)")
+            }
+            .markdownParser(customParser)
+        }
+        .render()
+
+        XCTAssertEqual(html, """
+        <div>\
+        <p><a href="/first">First</a></p>\
+        <div><p><b><a href="/second">Second</a></b></p></div>\
+        </div>
         """)
     }
 }


### PR DESCRIPTION
- Bump Plot to version `0.9.0`.
- Publish now ships with a few implementations of Plot's new `Component` protocol - specifically `Markdown` (for rendering Markdown inline within a component hierarchy), `VideoPlayer` (for rendering an inline video player), and an extension that makes it possible to directly use Plot's `AudioPlayer` component with Publish's `Audio` model.
- The `Content.Body` type now also conforms to `Component`, which makes it possible to place such instances directly within a component hierarchy. That type has now also been fully documented, since it was previously missing documentation for some of its properties and initializers.
- The built-in Foundation theme as been rewritten using the new component API. While it remains functionally identical to the previous implementation, it should act as a nice example of how this new API can be used.
- Because Publish now ships with a type called `Markdown`, it's possible that some API users might need to disambiguate between this new type and Ink's `Markdown` type. However, that tradeoff was considered worth it, since using the new `Markdown` component will likely be a much more common use case.