### PR TITLE
Update Website.swift for sites without sections.

### DIFF
--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -9,6 +9,14 @@ import Plot
 
 /// Protocol that all `Website.SectionID` implementations must conform to.
 public protocol WebsiteSectionID: Decodable, Hashable, CaseIterable, RawRepresentable where RawValue == String {}
+/// Convienence implementation of SectionID to allow a website to be published without sections.
+/// To supress the generation of website sections, add `typealias SectionID = NoSectionID` to 
+/// the `Website` definition.
+struct NoSectionID: WebsiteSectionID {
+    static var allCases: [NoSectionID] = []
+    var rawValue: String
+    init?(rawValue: String) { return nil }
+}
 /// Protocol that all `Website.ItemMetadata` implementations must conform to.
 public typealias WebsiteItemMetadata = Decodable & Hashable
 


### PR DESCRIPTION
Implementing a website without sections seems to be quite esoteric at the moment. This is an attempt to improve the situation, by providing a convenience implementation of WebsiteSectionID for just that purpose.