### PR TITLE
Checkout target deployment destination

### DIFF
--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -41,10 +41,7 @@ public extension DeploymentMethod {
         DeploymentMethod(name: "Git (\(remote))") { context in
             let folder = try context.createDeploymentFolder(withPrefix: "Git") { folder in
                 if !folder.containsSubfolder(named: ".git") {
-                    try shellOut(
-                        to: .gitInit(),
-                        at: folder.path
-                    )
+                    try shellOut(to: .gitInit(), at: folder.path)
 
                     try shellOut(
                         to: "git remote add origin \(remote)",

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -59,6 +59,11 @@ public extension DeploymentMethod {
                     at: folder.path
                 )
 
+                try shellOut(
+                    to: .gitCheckout(branch: branch),
+                    at: folder.path
+                )
+
                 try folder.empty()
             }
 

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -41,7 +41,10 @@ public extension DeploymentMethod {
         DeploymentMethod(name: "Git (\(remote))") { context in
             let folder = try context.createDeploymentFolder(withPrefix: "Git") { folder in
                 if !folder.containsSubfolder(named: ".git") {
-                    try shellOut(to: .gitInit(), at: folder.path)
+                    try shellOut(
+                        to: "git init -b \(branch)",
+                        at: folder.path
+                    )
 
                     try shellOut(
                         to: "git remote add origin \(remote)",

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -42,7 +42,7 @@ public extension DeploymentMethod {
             let folder = try context.createDeploymentFolder(withPrefix: "Git") { folder in
                 if !folder.containsSubfolder(named: ".git") {
                     try shellOut(
-                        to: "git init -b \(branch)",
+                        to: "git init --initial-branch=\(branch)",
                         at: folder.path
                     )
 

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -42,7 +42,7 @@ public extension DeploymentMethod {
             let folder = try context.createDeploymentFolder(withPrefix: "Git") { folder in
                 if !folder.containsSubfolder(named: ".git") {
                     try shellOut(
-                        to: "git init --initial-branch=\(branch)",
+                        to: .gitInit(),
                         at: folder.path
                     )
 
@@ -63,7 +63,7 @@ public extension DeploymentMethod {
                 )
 
                 try shellOut(
-                    to: .gitCheckout(branch: branch),
+                    to: "git checkout \(branch) || git checkout -b \(branch)",
                     at: folder.path
                 )
 

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -61,7 +61,9 @@ final class DeploymentTests: PublishTestCase {
         let repo = try container.createSubfolder(named: "Repo")
 
         try shellOut(to: [
-            "git init --initial-branch=master",
+            "git init",
+            // Not all git installations init with a master branch.
+            "git checkout master || git checkout -b master",
             "git config --local receive.denyCurrentBranch updateInstead"
         ], at: remote.path)
 
@@ -86,7 +88,14 @@ final class DeploymentTests: PublishTestCase {
         let remote = try container.createSubfolder(named: "Remote.git")
         let repo = try container.createSubfolder(named: "Repo")
 
-        try shellOut(to: "git init --initial-branch=master", at: remote.path)
+        try shellOut(
+          to: [
+            "git init",
+            // Not all git installations init with a master branch.
+            "git checkout master || git checkout -b master"
+          ],
+          at: remote.path
+        )
         
         // First generate
         try publishWebsite(in: repo, using: [

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -61,7 +61,7 @@ final class DeploymentTests: PublishTestCase {
         let repo = try container.createSubfolder(named: "Repo")
 
         try shellOut(to: [
-            "git init",
+            "git init --initial-branch=master",
             "git config --local receive.denyCurrentBranch updateInstead"
         ], at: remote.path)
 
@@ -86,7 +86,7 @@ final class DeploymentTests: PublishTestCase {
         let remote = try container.createSubfolder(named: "Remote.git")
         let repo = try container.createSubfolder(named: "Repo")
 
-        try shellOut(to: .gitInit(), at: remote.path)
+        try shellOut(to: "git init --initial-branch=master", at: remote.path)
         
         // First generate
         try publishWebsite(in: repo, using: [


### PR DESCRIPTION
When using the `.git` or `.github` deployment strategies with a custom branch specified (for example, `gh-pages`), the deployment will fail with the following error message:
```
[info] error: src refspec gh-pages does not match any
error: failed to push some refs to 'github.com:my-name/my-name.github.io.git'
```

(This error can be seen in [this GitHub action](https://github.com/schrismartin/schrismartin.github.io/runs/4135033142?check_suite_focus=true#step:3:223))

This occurs because, when creating the `.publish/GitDeploy` directory, the HTML is generated in the default created branch (on some computers, `master`, and in others `main`) rather than the branch specified in the `branch` parameter. 

This PR adds a single additional command to checkout the specified branch pulled from the previous step. 

Alternatively, I considered calling `git init -b \(branch)` to initialize the internal repo with the intended branch. I chose the submitted approach instead because it doesn't require the implementer to remove their `.publish` directory for the change to apply.