### PR TITLE
Fix tests when default git branch is not master

### DIFF
--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -41,7 +41,7 @@ public extension DeploymentMethod {
         DeploymentMethod(name: "Git (\(remote))") { context in
             let folder = try context.createDeploymentFolder(withPrefix: "Git") { folder in
                 if !folder.containsSubfolder(named: ".git") {
-                    try shellOut(to: .gitInit(), at: folder.path)
+                    try shellOut(to: "git init -b \(branch)", at: folder.path)
 
                     try shellOut(
                         to: "git remote add origin \(remote)",

--- a/Sources/Publish/API/DeploymentMethod.swift
+++ b/Sources/Publish/API/DeploymentMethod.swift
@@ -41,7 +41,7 @@ public extension DeploymentMethod {
         DeploymentMethod(name: "Git (\(remote))") { context in
             let folder = try context.createDeploymentFolder(withPrefix: "Git") { folder in
                 if !folder.containsSubfolder(named: ".git") {
-                    try shellOut(to: "git init -b \(branch)", at: folder.path)
+                    try shellOut(to: "git init && git checkout -b \(branch)", at: folder.path)
 
                     try shellOut(
                         to: "git remote add origin \(remote)",

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -60,8 +60,10 @@ final class DeploymentTests: PublishTestCase {
         let remote = try container.createSubfolder(named: "Remote.git")
         let repo = try container.createSubfolder(named: "Repo")
 
+        let branch = "master"
+
         try shellOut(to: [
-            "git init",
+            "git init -b \(branch)",
             "git config --local receive.denyCurrentBranch updateInstead"
         ], at: remote.path)
 
@@ -74,7 +76,7 @@ final class DeploymentTests: PublishTestCase {
         CommandLine.arguments.append("--deploy")
 
         try publishWebsite(in: repo, using: [
-            .deploy(using: .git(remote.path))
+            .deploy(using: .git(remote.path, branch: branch))
         ])
 
         let indexFile = try remote.file(named: "index.html")
@@ -86,7 +88,9 @@ final class DeploymentTests: PublishTestCase {
         let remote = try container.createSubfolder(named: "Remote.git")
         let repo = try container.createSubfolder(named: "Repo")
 
-        try shellOut(to: .gitInit(), at: remote.path)
+        let branch = "master"
+
+        try shellOut(to: "git init -b \(branch)", at: remote.path)
         
         // First generate
         try publishWebsite(in: repo, using: [
@@ -99,10 +103,9 @@ final class DeploymentTests: PublishTestCase {
         var thrownError: PublishingError?
 
         do {
-            try publishWebsite(
-                in: repo,
-                using: [.deploy(using: .git(remote.path))]
-            )
+            try publishWebsite(in: repo, using: [
+                .deploy(using: .git(remote.path, branch: branch))
+            ])
         } catch {
             thrownError = error as? PublishingError
         }

--- a/Tests/PublishTests/Tests/DeploymentTests.swift
+++ b/Tests/PublishTests/Tests/DeploymentTests.swift
@@ -63,7 +63,8 @@ final class DeploymentTests: PublishTestCase {
         let branch = "master"
 
         try shellOut(to: [
-            "git init -b \(branch)",
+            "git init",
+            "git checkout -b \(branch)",
             "git config --local receive.denyCurrentBranch updateInstead"
         ], at: remote.path)
 
@@ -90,7 +91,10 @@ final class DeploymentTests: PublishTestCase {
 
         let branch = "master"
 
-        try shellOut(to: "git init -b \(branch)", at: remote.path)
+        try shellOut(to: [
+            "git init",
+            "git checkout -b \(branch)"
+        ], at: remote.path)
         
         // First generate
         try publishWebsite(in: repo, using: [


### PR DESCRIPTION
## Issue

Two tests fail when git default branch name is not "master".

## Context

Since git version 2.28, the default branch name when creating a new repo can be set by adding 

```
git config --global init.defaultbranch branchname
```

When this has been set, `testGitDeploymentMethod()` and `testGitDeploymentMethodWithError()` fail, as they assume that the default branch is called "master".

## Resolution

Updated tests to use a deterministic branch name.

Also changed git `DeploymentMethod` to create the local repository using the branch name specified by the publishing step, rather than default branch name configured in git.