### PR TITLE
Add HTML Mutator capability for Plugins.

### DIFF
--- a/Sources/Publish/API/Mutations.swift
+++ b/Sources/Publish/API/Mutations.swift
@@ -6,3 +6,8 @@
 
 /// Closure type used to implement content mutations.
 public typealias Mutations<T> = (inout T) throws -> Void
+public typealias HTMLIndexMutation<Site:Website> = (PublishingContext<Site>, String) throws -> String
+public typealias HTMLSectionMutation<Site:Website> = (PublishingContext<Site>, Section<Site>, String) throws -> String
+public typealias HTMLItemMutation<Site:Website> = (PublishingContext<Site>, Item<Site>, String) throws -> String
+public typealias HTMLPageMutation<Site:Website> = (PublishingContext<Site>, Page, String) throws -> String
+public typealias HTMLAllMutation<Site:Website> = (PublishingContext<Site>, Location, String) throws -> String

--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -34,6 +34,8 @@ public struct PublishingContext<Site: Website> {
     /// Any date when the website was last generated.
     public private(set) var lastGenerationDate: Date?
 
+    internal var htmlMutations = HTMLMutations<Site>()
+
     private let folders: Folder.Group
     private var tagCache = TagCache()
     private var stepName: String
@@ -272,6 +274,10 @@ public extension PublishingContext {
                 reason: .pageMutationFailed(error)
             )
         }
+    }
+
+    mutating func mutateIndexHTML(using mutation: @escaping HTMLIndexMutation<Site>) {
+        self.htmlMutations.indexMutations.append(mutation)
     }
 }
 

--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -279,6 +279,23 @@ public extension PublishingContext {
     mutating func mutateIndexHTML(using mutation: @escaping HTMLIndexMutation<Site>) {
         self.htmlMutations.indexMutations.append(mutation)
     }
+
+    mutating func mutateSectionHTML(using mutation: @escaping HTMLSectionMutation<Site>) {
+        self.htmlMutations.sectionMutations.append(mutation)
+    }
+
+    mutating func mutateItemHTML(using mutation: @escaping HTMLItemMutation<Site>) {
+        self.htmlMutations.itemMutations.append(mutation)
+    }
+
+    mutating func mutatePageHTML(using mutation: @escaping HTMLPageMutation<Site>) {
+        self.htmlMutations.pageMutations.append(mutation)
+    }
+
+    mutating func mutateAllHTML(using mutation: @escaping HTMLAllMutation<Site>) {
+        self.htmlMutations.allMutations.append(mutation)
+    }
+
 }
 
 internal extension PublishingContext {

--- a/Sources/Publish/API/PublishingStep.swift
+++ b/Sources/Publish/API/PublishingStep.swift
@@ -227,6 +227,13 @@ public extension PublishingStep {
         }
     }
 
+    static func mutateIndexHtml(using mutation: @escaping HTMLIndexMutation<Site>) -> Self {
+        step(named: "Mutate Index HTML") { context in
+            context.mutateIndexHTML(using: mutation)
+        }
+
+    }
+
     /// Sort all items, optionally within a specific section, using a key path.
     /// - parameter section: Any specific section to sort all items within.
     /// - parameter keyPath: The key path to use when sorting.

--- a/Sources/Publish/API/PublishingStep.swift
+++ b/Sources/Publish/API/PublishingStep.swift
@@ -227,12 +227,38 @@ public extension PublishingStep {
         }
     }
 
-    static func mutateIndexHtml(using mutation: @escaping HTMLIndexMutation<Site>) -> Self {
+    static func mutateIndexHTML(using mutation: @escaping HTMLIndexMutation<Site>) -> Self {
         step(named: "Mutate Index HTML") { context in
             context.mutateIndexHTML(using: mutation)
         }
-
     }
+
+    static func mutateSectionHTML(using mutation: @escaping HTMLSectionMutation<Site>) -> Self {
+        step(named: "Mutate Section HTML") { context in
+            context.mutateSectionHTML(using: mutation)
+        }
+    }
+
+    static func mutateItemHTML(using mutation: @escaping HTMLItemMutation<Site>) -> Self {
+        step(named: "Mutate Item HTML") { context in
+            context.mutateItemHTML(using: mutation)
+        }
+    }
+
+    static func mutatePageHTML(using mutation: @escaping HTMLPageMutation<Site>) -> Self {
+        step(named: "Mutate Page HTML") { context in
+            context.mutatePageHTML(using: mutation)
+        }
+    }
+
+    static func mutateAllHTML(using mutation: @escaping HTMLAllMutation<Site>) -> Self {
+        step(named: "Mutate All HTML") { context in
+            context.mutateAllHTML(using: mutation)
+        }
+    }
+
+
+
 
     /// Sort all items, optionally within a specific section, using a key path.
     /// - parameter section: Any specific section to sort all items within.

--- a/Sources/Publish/Internal/HTMLMutations.swift
+++ b/Sources/Publish/Internal/HTMLMutations.swift
@@ -1,0 +1,58 @@
+import Plot
+
+internal struct HTMLMutations<Site: Website> {
+    var indexMutations: [HTMLIndexMutation<Site>] = []
+    var sectionMutations: [HTMLSectionMutation<Site>] = []
+    var itemMutations: [HTMLItemMutation<Site>] = []
+    var pageMutations: [HTMLPageMutation<Site>] = []
+    var allMutations: [HTMLAllMutation<Site>] = []
+
+    public init() {
+    }
+
+    func mutateHtml(context: PublishingContext<Site>, renderedHtml: String) throws -> String {
+        var mutatedHtml = renderedHtml
+        for mutation in indexMutations {
+            mutatedHtml = try mutation(context, mutatedHtml)
+        }
+
+        for mutation in allMutations {
+            mutatedHtml = try mutation(context, context.index, mutatedHtml)
+        }
+        return mutatedHtml
+    }
+
+    func mutateHtml(context: PublishingContext<Site>, section: Section<Site>, renderedHtml: String) throws -> String {
+        var mutatedHtml = renderedHtml
+        for mutation in sectionMutations {
+            mutatedHtml = try mutation(context, section, mutatedHtml)
+        }
+        for mutation in allMutations {
+            mutatedHtml = try mutation(context, section, mutatedHtml)
+        }
+        return mutatedHtml
+    }
+
+    func mutateHtml(context: PublishingContext<Site>, item: Item<Site>, renderedHtml: String) throws -> String {
+        var mutatedHtml = renderedHtml
+        for mutation in itemMutations {
+            mutatedHtml = try mutation(context, item, mutatedHtml)
+        }
+        for mutation in allMutations {
+            mutatedHtml = try mutation(context, item, mutatedHtml)
+        }
+        return mutatedHtml
+    }
+
+    func mutateHtml(context: PublishingContext<Site>, page: Page, renderedHtml: String) throws -> String {
+        var mutatedHtml = renderedHtml
+        for mutation in pageMutations {
+            mutatedHtml = try mutation(context, page, mutatedHtml)
+        }
+        for mutation in allMutations {
+            mutatedHtml = try mutation(context, page, mutatedHtml)
+        }
+        return mutatedHtml
+    }
+}
+

--- a/Sources/Publish/Internal/HTMLMutations.swift
+++ b/Sources/Publish/Internal/HTMLMutations.swift
@@ -15,10 +15,7 @@ internal struct HTMLMutations<Site: Website> {
         for mutation in indexMutations {
             mutatedHtml = try mutation(context, mutatedHtml)
         }
-
-        for mutation in allMutations {
-            mutatedHtml = try mutation(context, context.index, mutatedHtml)
-        }
+        mutatedHtml = try mutateHtml(context: context, location: context.index, renderedHtml: mutatedHtml)
         return mutatedHtml
     }
 
@@ -27,9 +24,7 @@ internal struct HTMLMutations<Site: Website> {
         for mutation in sectionMutations {
             mutatedHtml = try mutation(context, section, mutatedHtml)
         }
-        for mutation in allMutations {
-            mutatedHtml = try mutation(context, section, mutatedHtml)
-        }
+        mutatedHtml = try mutateHtml(context: context, location: section, renderedHtml: mutatedHtml)
         return mutatedHtml
     }
 
@@ -38,9 +33,7 @@ internal struct HTMLMutations<Site: Website> {
         for mutation in itemMutations {
             mutatedHtml = try mutation(context, item, mutatedHtml)
         }
-        for mutation in allMutations {
-            mutatedHtml = try mutation(context, item, mutatedHtml)
-        }
+        mutatedHtml = try mutateHtml(context: context, location: item, renderedHtml: mutatedHtml)
         return mutatedHtml
     }
 
@@ -49,10 +42,17 @@ internal struct HTMLMutations<Site: Website> {
         for mutation in pageMutations {
             mutatedHtml = try mutation(context, page, mutatedHtml)
         }
+        mutatedHtml = try mutateHtml(context: context, location: page, renderedHtml: mutatedHtml)
+        return mutatedHtml
+    }
+
+    func mutateHtml(context: PublishingContext<Site>, location: Location, renderedHtml: String) throws -> String {
+        var mutatedHtml = renderedHtml
         for mutation in allMutations {
-            mutatedHtml = try mutation(context, page, mutatedHtml)
+            mutatedHtml = try mutation(context, location, mutatedHtml)
         }
         return mutatedHtml
     }
+
 }
 


### PR DESCRIPTION
Add HTML mutation capability to Plugins.  This allows Plugins to perform any number of last-minute changes on the raw HTML output.  Some examples:
 - HTML validation
 - pretty printing
 - minification
 - analytics tracking insertion
