### PR TITLE
Add Website option to ignore paths by name regex

### DIFF
--- a/Sources/Publish/API/PublishingContext.swift
+++ b/Sources/Publish/API/PublishingContext.swift
@@ -293,6 +293,7 @@ internal extension PublishingContext {
 
     func copyFileToOutput(_ file: File,
                           targetFolderPath: Path?) throws {
+        guard !site.shouldIgnore(name: file.name) else { return }
         try copyLocationToOutput(
             file,
             targetFolderPath: targetFolderPath,
@@ -302,6 +303,7 @@ internal extension PublishingContext {
 
     func copyFolderToOutput(_ folder: Folder,
                             targetFolderPath: Path?) throws {
+        guard !site.shouldIgnore(name: folder.name) else { return }
         try copyLocationToOutput(
             folder,
             targetFolderPath: targetFolderPath,
@@ -349,6 +351,7 @@ private extension PublishingContext {
         targetFolderPath: Path?,
         errorReason: FileIOError.Reason
     ) throws {
+        guard !site.shouldIgnore(name: location.name) else { return }
         let targetFolder = try targetFolderPath.map {
             try createOutputFolder(at: $0)
         }

--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -163,6 +163,8 @@ public extension Website {
         guard let ignoredPaths = ignoredPaths else { return false }
         return !ignoredPaths.filter({
             name.range(of: $0, options: .regularExpression) != nil
+            // Add `^` and `$` to the ends of the pattern to avoid unexpected matches. Matching something like "foo" anywhere in a filename requires wildcards, e.g. ".*foo.*". Extra line start/end markers don't affect matching, so there's no need to check for them before trying the pattern.
+            name.range(of: "^\($0)$", options: .regularExpression) != nil
         }).isEmpty
     }
 }

--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -40,6 +40,8 @@ public protocol Website {
     /// The configuration to use when generating tag HTML for the website.
     /// If this is `nil`, then no tag HTML will be generated.
     var tagHTMLConfig: TagHTMLConfiguration? { get }
+    /// File or folder names to exclude when adding Markdown files. Regular expressions may be used.
+    var ignoredPaths: [String]? { get }
 }
 
 // MARK: - Defaults
@@ -153,5 +155,14 @@ public extension Website {
     /// - parameter location: The location to return a URL for.
     func url(for location: Location) -> URL {
         url(for: location.path)
+    }
+    
+    var ignoredPaths: [String]? { nil }
+
+    func shouldIgnore(name: String) -> Bool {
+        guard let ignoredPaths = ignoredPaths else { return false }
+        return !ignoredPaths.filter({
+            name.range(of: $0, options: .regularExpression) != nil
+        }).isEmpty
     }
 }

--- a/Sources/Publish/Internal/MarkdownFileHandler.swift
+++ b/Sources/Publish/Internal/MarkdownFileHandler.swift
@@ -22,7 +22,7 @@ internal struct MarkdownFileHandler<Site: Website> {
         }
 
         for subfolder in folder.subfolders {
-            guard !context.site.shouldIgnore(name: subfolder.name) else { return }
+            guard !context.site.shouldIgnore(name: subfolder.name) else { continue }
             guard let sectionID = Site.SectionID(rawValue: subfolder.name.lowercased()) else {
                 try addPagesForMarkdownFiles(
                     inFolder: subfolder,
@@ -36,7 +36,7 @@ internal struct MarkdownFileHandler<Site: Website> {
             }
 
             for file in subfolder.files.recursive {
-                guard !context.site.shouldIgnore(name: file.name) else { return }
+                guard !context.site.shouldIgnore(name: file.name) else { continue }
                 guard file.isMarkdown else { continue }
 
                 if file.nameExcludingExtension == "index", file.parent == subfolder {
@@ -88,7 +88,7 @@ private extension MarkdownFileHandler {
         factory: MarkdownContentFactory<Site>
     ) throws {
         for file in folder.files {
-            guard !context.site.shouldIgnore(name: file.name) else { return }
+            guard !context.site.shouldIgnore(name: file.name) else { continue }
             guard file.isMarkdown else { continue }
 
             if file.nameExcludingExtension == "index", !recursively {

--- a/Sources/Publish/Internal/MarkdownFileHandler.swift
+++ b/Sources/Publish/Internal/MarkdownFileHandler.swift
@@ -22,6 +22,7 @@ internal struct MarkdownFileHandler<Site: Website> {
         }
 
         for subfolder in folder.subfolders {
+            guard !context.site.shouldIgnore(name: subfolder.name) else { return }
             guard let sectionID = Site.SectionID(rawValue: subfolder.name.lowercased()) else {
                 try addPagesForMarkdownFiles(
                     inFolder: subfolder,
@@ -35,6 +36,7 @@ internal struct MarkdownFileHandler<Site: Website> {
             }
 
             for file in subfolder.files.recursive {
+                guard !context.site.shouldIgnore(name: file.name) else { return }
                 guard file.isMarkdown else { continue }
 
                 if file.nameExcludingExtension == "index", file.parent == subfolder {
@@ -86,6 +88,7 @@ private extension MarkdownFileHandler {
         factory: MarkdownContentFactory<Site>
     ) throws {
         for file in folder.files {
+            guard !context.site.shouldIgnore(name: file.name) else { return }
             guard file.isMarkdown else { continue }
 
             if file.nameExcludingExtension == "index", !recursively {

--- a/Tests/PublishTests/Tests/WebsiteTests.swift
+++ b/Tests/PublishTests/Tests/WebsiteTests.swift
@@ -81,4 +81,39 @@ final class WebsiteTests: PublishTestCase {
             URL(string: "https://swiftbysundell.com/mypage")
         )
     }
+    
+    func testIgnorePatterns() {
+        XCTAssertTrue(website.shouldIgnore(name: "templates"))
+        XCTAssertFalse(website.shouldIgnore(name: "templates1"))
+        XCTAssertFalse(website.shouldIgnore(name: "@templates"))
+        
+        XCTAssertTrue(website.shouldIgnore(name: "skip-this-file.md"))
+        XCTAssertTrue(website.shouldIgnore(name: "skip-this-file-too.png"))
+        XCTAssertTrue(website.shouldIgnore(name: "skip-this-file"))
+        XCTAssertFalse(website.shouldIgnore(name: "dont-skip-this-file"))
+
+        XCTAssertTrue(website.shouldIgnore(name: "notes"))
+        XCTAssertFalse(website.shouldIgnore(name: "notes1"))
+
+        XCTAssertTrue(website.shouldIgnore(name: "batter"))
+        XCTAssertTrue(website.shouldIgnore(name: "butter"))
+        XCTAssertFalse(website.shouldIgnore(name: "butter1"))
+        
+        XCTAssertTrue(website.shouldIgnore(name: "lisp"))
+        XCTAssertTrue(website.shouldIgnore(name: "lip"))
+        XCTAssertTrue(website.shouldIgnore(name: "lp"))
+        XCTAssertTrue(website.shouldIgnore(name: "l1234567890p"))
+        XCTAssertFalse(website.shouldIgnore(name: "lisp-too"))
+    }
 }
+
+private extension Website {
+    var ignoredPaths: [String]? { [
+        "templates", // Should only match the exact string
+        "skip-this-file.*", // Should match anyhing starting with "skip-this-file" and 0 or more chars after that
+        "^notes$", // Should match "notes" exactly and nothing else. Included because `shouldIgnore` adds a "^" and "$", which should not be affected by including those in the pattern.
+        "b.tter",
+        "l.*p"
+    ] }
+}
+

--- a/Tests/PublishTests/Tests/WebsiteTests.swift
+++ b/Tests/PublishTests/Tests/WebsiteTests.swift
@@ -107,7 +107,7 @@ final class WebsiteTests: PublishTestCase {
     }
 }
 
-private extension Website {
+extension Website {
     var ignoredPaths: [String]? { [
         "templates", // Should only match the exact string
         "skip-this-file.*", // Should match anyhing starting with "skip-this-file" and 0 or more chars after that


### PR DESCRIPTION
This replaces #121, which I'll remove. I'm making this update because I mistakenly sent #121 from the master branch instead of a feature branch. Sorry for any confusion.

This adds an optional `ignoredPaths` array to `Website` which may contain a list of regular expressions of file or folder names that should be ignored during publishing. Each file or folder name is compared to entries in the array using `range(of: name, options: .regularExpression)`, so wildcards may be used. A structure that adopts `Website` may optionally declare something like this to affect the output:

```swift
    var ignoredPaths: [String]? { ["templates", "skip-this-file*"] }
```

My motivation for this is that I have a folder of template documents used on my site, which should not be copied to the site output.