### PR TITLE
Fix bug where .standAloneFiles doesn't work with section indexes

### DIFF
--- a/Sources/Publish/API/Item.swift
+++ b/Sources/Publish/API/Item.swift
@@ -61,3 +61,17 @@ private extension Item {
         "\(sectionID.rawValue)/\(relativePath)"
     }
 }
+
+public extension Item {
+    /// An `Item` location depends on the site's file mode. This function returns the appropriat path for the site.
+    /// - Parameter site: The site being published
+    /// - Returns: Path to the `Item` suitable for use in a list of links in a generated section index page.
+    func linkPath(for site:Site) -> String {
+        switch site.fileMode {
+        case .foldersAndIndexFiles:
+            return "/\(sectionID.rawValue)/\(relativePath)"
+        case .standAloneFiles:
+            return "/\(sectionID.rawValue)/\(relativePath).html"
+        }
+    }
+}

--- a/Sources/Publish/API/PublishingStep.swift
+++ b/Sources/Publish/API/PublishingStep.swift
@@ -333,13 +333,13 @@ public extension PublishingStep {
     static func generateHTML(
         withTheme theme: Theme<Site>,
         indentation: Indentation.Kind? = nil,
-        fileMode: HTMLFileMode = .foldersAndIndexFiles
+        fileMode: HTMLFileMode? = nil
     ) -> Self {
         step(named: "Generate HTML") { context in
             let generator = HTMLGenerator(
                 theme: theme,
                 indentation: indentation,
-                fileMode: fileMode,
+                fileMode: fileMode ?? context.site.fileMode,
                 context: context
             )
 

--- a/Sources/Publish/API/Theme+Foundation.swift
+++ b/Sources/Publish/API/Theme+Foundation.swift
@@ -197,7 +197,7 @@ private struct ItemList<Site: Website>: Component {
     var body: Component {
         List(items) { item in
             Article {
-                H1(Link(item.title, url: item.path.absoluteString))
+                H1(Link(item.title, url: item.linkPath(for: site)))
                 ItemTagList(item: item, site: site)
                 Paragraph(item.description)
             }

--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -40,6 +40,8 @@ public protocol Website {
     /// The configuration to use when generating tag HTML for the website.
     /// If this is `nil`, then no tag HTML will be generated.
     var tagHTMLConfig: TagHTMLConfiguration? { get }
+    /// Preferred file-generation mode. Default is `.foldersAndIndexFiles`
+    var fileMode: HTMLFileMode { get }
 }
 
 // MARK: - Defaults
@@ -154,4 +156,7 @@ public extension Website {
     func url(for location: Location) -> URL {
         url(for: location.path)
     }
+    
+    /// Provide a default file mode.
+    var fileMode: HTMLFileMode { .foldersAndIndexFiles }
 }

--- a/Tests/PublishTests/Infrastructure/PublishTestCase.swift
+++ b/Tests/PublishTests/Infrastructure/PublishTestCase.swift
@@ -14,13 +14,15 @@ class PublishTestCase: XCTestCase {
     func publishWebsite(
         in folder: Folder? = nil,
         using steps: [PublishingStep<WebsiteStub.WithoutItemMetadata>],
-        content: [Path : String] = [:]
+        content: [Path : String] = [:],
+        fileMode: HTMLFileMode = .foldersAndIndexFiles
     ) throws -> PublishedWebsite<WebsiteStub.WithoutItemMetadata> {
         try performWebsitePublishing(
             in: folder,
             using: steps,
             files: content,
-            filePathPrefix: "Content/"
+            filePathPrefix: "Content/",
+            fileMode: fileMode
         )
     }
 
@@ -33,9 +35,12 @@ class PublishTestCase: XCTestCase {
         plugins: [Plugin<WebsiteStub.WithoutItemMetadata>] = [],
         expectedHTML: [Path : String],
         allowWhitelistedOutputFiles: Bool = true,
+        fileMode: HTMLFileMode = .foldersAndIndexFiles,
         file: StaticString = #file,
         line: UInt = #line
     ) throws {
+        site.fileMode = fileMode
+        
         let folder = try folder ?? Folder.createTemporary()
 
         let contentFolderName = "Content"
@@ -65,6 +70,7 @@ class PublishTestCase: XCTestCase {
         in folder: Folder? = nil,
         using steps: [PublishingStep<WebsiteStub.WithPodcastMetadata>],
         content: [Path : String] = [:],
+        fileMode: HTMLFileMode = .foldersAndIndexFiles,
         file: StaticString = #file,
         line: UInt = #line
     ) throws {
@@ -72,7 +78,8 @@ class PublishTestCase: XCTestCase {
             in: folder,
             using: steps,
             files: content,
-            filePathPrefix: "Content/"
+            filePathPrefix: "Content/",
+            fileMode: fileMode
         )
     }
 
@@ -136,12 +143,14 @@ class PublishTestCase: XCTestCase {
     func publishWebsite<T: WebsiteItemMetadata>(
         withItemMetadataType itemMetadataType: T.Type,
         using steps: [PublishingStep<WebsiteStub.WithItemMetadata<T>>],
-        content: [Path : String] = [:]
+        content: [Path : String] = [:],
+        fileMode: HTMLFileMode = .foldersAndIndexFiles
     ) throws -> PublishedWebsite<WebsiteStub.WithItemMetadata<T>> {
         try performWebsitePublishing(
             using: steps,
             files: content,
-            filePathPrefix: "Content/"
+            filePathPrefix: "Content/",
+            fileMode: fileMode
         )
     }
 
@@ -197,13 +206,16 @@ private extension PublishTestCase {
         in folder: Folder? = nil,
         using steps: [PublishingStep<T>],
         files: [Path : String],
-        filePathPrefix: String = ""
+        filePathPrefix: String = "",
+        fileMode: HTMLFileMode
     ) throws -> PublishedWebsite<T> {
         let folder = try folder ?? Folder.createTemporary()
 
         try addFiles(withContent: files, to: folder, pathPrefix: filePathPrefix)
 
-        return try T().publish(
+        let site = T()
+        site.fileMode = fileMode
+        return try site.publish(
             at: Path(folder.path),
             using: steps
         )

--- a/Tests/PublishTests/Infrastructure/WebsiteStub.swift
+++ b/Tests/PublishTests/Infrastructure/WebsiteStub.swift
@@ -20,7 +20,8 @@ class WebsiteStub {
     var imagePath: Path? = nil
     var faviconPath: Path? = nil
     var tagHTMLConfig: TagHTMLConfiguration? = .default
-
+    var fileMode: HTMLFileMode = .foldersAndIndexFiles
+    
     required init() {}
 
     func title(for sectionID: WebsiteStub.SectionID) -> String {

--- a/Tests/PublishTests/Tests/HTMLGenerationTests.swift
+++ b/Tests/PublishTests/Tests/HTMLGenerationTests.swift
@@ -259,11 +259,13 @@ final class HTMLGenerationTests: PublishTestCase {
         let folder = try Folder.createTemporary()
         let theme = Theme(htmlFactory: htmlFactory)
 
-        try publishWebsite(in: folder, using: [
-            .addItem(Item.stub(withPath: "item").setting(\.tags, to: ["tag"])),
-            .addItem(Item.stub(withPath: "rawValueItem", sectionID: .customRawValue).setting(\.tags, to: ["tag"])),
-            .generateHTML(withTheme: theme, fileMode: .standAloneFiles)
-        ])
+        try publishWebsite(in: folder,
+                           using: [
+                            .addItem(Item.stub(withPath: "item").setting(\.tags, to: ["tag"])),
+                            .addItem(Item.stub(withPath: "rawValueItem", sectionID: .customRawValue).setting(\.tags, to: ["tag"])),
+                            .generateHTML(withTheme: theme)
+                           ],
+                           fileMode: .standAloneFiles)
 
         try verifyOutput(
             in: folder,


### PR DESCRIPTION
This PR fixes a bug in the current code where using `.standAloneFiles` produces broken links on generated section pages.

## The bug this addresses

You can reproduce the bug as follows:

1. Create a new site:

```
mkdir testsite
cd testsite
publish new
```

2. Edit `main.swift` so that the publishing code looks like this:

```swift
try Testsite().publish(using: [
    .addMarkdownFiles(),
    .generateHTML(withTheme: .foundation, fileMode: .standAloneFiles)
])
```

3. Build the site. Serve it using either `publish run` or `python3 -m http.server 8000`

4. Navigate to `http://localhost:8000/posts/` and click on the "My first post" link.

The link is broken. It points to `http://localhost:8000/posts/first-post`, but since HTML generation used the `.standAloneFiles` mode, there's no `index.html` at that path.

At first this seems the problem is that the foundation theme doesn't support `.standAloneFiles`, which would be fine. However it's impossible for a theme to discover the file mode, so it's impossible to fix this at the theme level. No theme can find the correct path in this case.

## The fix

I'm addressing this by moving file mode to `Website` so that it will be more widely available:

- `Website` now includes `var fileMode: HTMLFileMode`, and an extension defaults this to `.foldersAndIndexFiles`.

- In `generateHTML(...)`, the `fileMode` argument now defaults to nil instead of `.foldersAndIndexFiles`. The `HTMLGenerator` instance will use `fileMode` if it's provided, which means existing code will still work. If file mode is not provided, it uses the site's value described above.

- `Item` has a new `func linkPath(for site:Site) -> String` that provides the correct destination for the item based on the site's file mode.

- The foundation theme has been modified to use this new function on `Item`, to demonstrate how a theme can make use of this functionality.

Unit tests have also been updated.

The effect of all of this is that in the reproduction steps above

- If `. foldersAndIndexFiles` is used, the link to "My first post" is still `http://localhost:8000/posts/first-post`
- If `.standAloneFiles` is used, the link is now `http://localhost:8000/posts/first-post.html`.
