### PR TITLE
Keep resources folder

### DIFF
--- a/Sources/PublishCLICore/ProjectGenerator.swift
+++ b/Sources/PublishCLICore/ProjectGenerator.swift
@@ -62,7 +62,8 @@ private extension ProjectGenerator {
     }
 
     func generateResourcesFolder() throws {
-        try folder.createSubfolder(named: "Resources")
+        let resourcesFolder = try folder.createSubfolder(named: "Resources")
+        try resourcesFolder.createFile(named: ".gitkeep")
     }
 
     func generateContentFolder() throws {


### PR DESCRIPTION
I want to prevent an error because `Resources` folder does not exist.

```
$ publish-cli generate
...
[step] Copy 'Resources' files
[path] Resources
[info] Folder not found
...
```