### PR TITLE
Uso `sudo` to Move Into Protected Directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 install:
 	swift build -c release
-	install .build/release/publish-cli /usr/local/bin/publish
+	sudo install .build/release/publish-cli /usr/local/bin/publish


### PR DESCRIPTION
## Description

This is the error I was getting without `sudo`:

```sh
swift build -c release
[…]
Building for production...
<unknown>:0: warning: 'self' refers to the method 'HTMLAnchorTarget.self', which may be unexpected
<unknown>:0: note: use 'HTMLAnchorTarget.self' to silence this warning
[11/11] Linking publish-cli
Build complete! (29.03s)
install .build/release/publish-cli /usr/local/bin/publish
install: /usr/local/bin/publish: Permission denied
make: *** [install] Error 71
```

With sudo it works:

```sh
swift build -c release
Building for production...
Build complete! (0.18s)
sudo install .build/release/publish-cli /usr/local/bin/publish
Password:
```

Without sudo I get the "permission denied" issue even being the root/admin of this computer 🤷 