### PR TITLE
Use Publish version `0.9.0` in Command Line Tool.

### DIFF
--- a/Sources/PublishCLI/main.swift
+++ b/Sources/PublishCLI/main.swift
@@ -15,7 +15,7 @@ let cli = CLI(
     publishRepositoryURL: URL(
         string: "https://github.com/johnsundell/publish.git"
     )!,
-    publishVersion: "0.8.0"
+    publishVersion: "0.9.0"
 )
 
 do {


### PR DESCRIPTION
Upgrading `Publish` to its current latest release version `0.9.0` in Command Line Tool`.