### PR TITLE
Nmccann/watch files

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "FileWatcher",
+        "repositoryURL": "https://github.com/eonist/FileWatcher.git",
+        "state": {
+          "branch": null,
+          "revision": "e67c2a99502eade343fecabeca8c57e749a55b59",
+          "version": "0.2.3"
+        }
+      },
+      {
         "package": "Ink",
         "repositoryURL": "https://github.com/johnsundell/ink.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -72,7 +72,7 @@ let package = Package(
         ),
         .target(
             name: "PublishCLICore",
-            dependencies: ["Publish", "FileWatcher"]
+            dependencies: ["Publish", .byName(name: "FileWatcher", condition: .when(platforms: [.macOS]))]
         ),
         .testTarget(
             name: "PublishTests",

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,13 @@ let package = Package(
             name: "CollectionConcurrencyKit",
             url: "https://github.com/johnsundell/collectionConcurrencyKit.git",
             from: "0.1.0"
+        ),
+        .package(
+            name: "FileWatcher",
+            url: "https://github.com/eonist/FileWatcher.git",
+            from: "0.2.3"
         )
+
     ],
     targets: [
         .target(
@@ -66,7 +72,7 @@ let package = Package(
         ),
         .target(
             name: "PublishCLICore",
-            dependencies: ["Publish"]
+            dependencies: ["Publish", "FileWatcher"]
         ),
         .testTarget(
             name: "PublishTests",

--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -1,20 +1,104 @@
 /**
-*  Publish
-*  Copyright (c) John Sundell 2019
-*  MIT license, see LICENSE file for details
-*/
+ *  Publish
+ *  Copyright (c) John Sundell 2019
+ *  MIT license, see LICENSE file for details
+ */
 
 import Foundation
 import Files
 import ShellOut
+import FileWatcher
 
 internal struct WebsiteRunner {
+    static let normalTerminationStatus = 15
+    static let debounceInterval: TimeInterval = 3
+    static let runLoopInterval: TimeInterval = 0.1
     let folder: Folder
-    var portNumber: Int
+    let portNumber: Int
+    let shouldWatch: Bool
 
     func run() throws {
+        var lastModified: Date?
+        var watcher: FileWatcher?
+        let serverProcess: Process = try generateAndRun()
+
+        if shouldWatch {
+            watcher = try startWatcher {
+                if lastModified == nil {
+                    let file = try? File(path: $0)
+                    print("Change detected at \(file?.name ?? "Unknown"), scheduling regeneration")
+                }
+                lastModified = Date()
+            }
+        }
+
+        let interruptHandler = registerInterruptHandler {
+            watcher?.stop()
+            serverProcess.terminate()
+            exit(0)
+        }
+
+        interruptHandler.resume()
+
+        while true {
+            defer {
+                RunLoop.main.run(until: Date(timeIntervalSinceNow: Self.runLoopInterval))
+            }
+
+            guard let date = lastModified, date.timeIntervalSinceNow < -Self.debounceInterval else {
+                continue
+            }
+
+            lastModified = nil
+
+            print("Regenerating...")
+            let generator = WebsiteGenerator(folder: folder)
+            do {
+                try generator.generate()
+            } catch {
+                outputErrorMessage("Regeneration failed")
+            }
+        }
+    }
+}
+
+private extension WebsiteRunner {
+    var foldersToWatch: [Folder] {
+        get throws {
+            try ["Sources", "Resources", "Content"].map(folder.subfolder(named:))
+        }
+    }
+
+    func startWatcher(_ didChange: @escaping (String) -> Void) throws -> FileWatcher {
+        let filePaths = try foldersToWatch.map(\.path)
+        let watcher = FileWatcher(filePaths)
+
+        watcher.callback = { event in
+            if event.isFileChanged || event.isDirectoryChanged {
+                didChange(event.path)
+            }
+        }
+
+        watcher.start()
+        return watcher
+    }
+
+    func registerInterruptHandler(_ handler: @escaping () -> Void) -> DispatchSourceSignal {
+        let interruptHandler = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+
+        signal(SIGINT, SIG_IGN)
+
+        interruptHandler.setEventHandler(handler: handler)
+        return interruptHandler
+    }
+
+    func generate() throws {
         let generator = WebsiteGenerator(folder: folder)
         try generator.generate()
+    }
+
+    func generateAndRun() throws -> Process {
+        try generate()
 
         let outputFolder = try resolveOutputFolder()
 
@@ -24,7 +108,7 @@ internal struct WebsiteRunner {
         print("""
         🌍 Starting web server at http://localhost:\(portNumber)
 
-        Press ENTER to stop the server and exit
+        Press CTRL+C to stop the server and exit
         """)
 
         serverQueue.async {
@@ -44,12 +128,9 @@ internal struct WebsiteRunner {
             exit(1)
         }
 
-        _ = readLine()
-        serverProcess.terminate()
+        return serverProcess
     }
-}
 
-private extension WebsiteRunner {
     func resolveOutputFolder() throws -> Folder {
         do { return try folder.subfolder(named: "Output") }
         catch { throw CLIError.outputFolderNotFound }
@@ -70,6 +151,20 @@ private extension WebsiteRunner {
             """
         }
 
-        fputs("\n❌ Failed to start local web server:\n\(message)\n", stderr)
+        outputErrorMessage("Failed to start local web server:\n\(message)")
+    }
+
+    func outputErrorMessage(_ message: String) {
+        fputs("\n❌ \(message)\n", stderr)
+    }
+}
+
+private extension FileWatcherEvent {
+    var isFileChanged: Bool {
+        fileRenamed || fileRemoved || fileCreated || fileModified
+    }
+
+    var isDirectoryChanged: Bool {
+        dirRenamed || dirRemoved || dirCreated || dirModified
     }
 }

--- a/Sources/PublishCLICore/WebsiteRunner.swift
+++ b/Sources/PublishCLICore/WebsiteRunner.swift
@@ -7,13 +7,15 @@
 import Foundation
 import Files
 import ShellOut
+
 #if canImport(FileWatcher)
 import FileWatcher
 #endif
 
 internal struct WebsiteRunner {
+    static let nanosecondsPerSecond: UInt64 = 1_000_000_000
     static let normalTerminationStatus = 15
-    static let debounceDuration = 3 * NSEC_PER_SEC
+    static let debounceDuration = 3 * nanosecondsPerSecond
     static let runLoopInterval: TimeInterval = 0.1
     static let exitMessage = "Press CTRL+C to stop the server and exit"
     let folder: Folder


### PR DESCRIPTION
This introduces a new (very small) dependency to allow for optional file watching, which is just a lightweight wrapper around Apple's own file watching capabilities. This dependency imports Cocoa, though I've seen on another pull request that limiting to building on Apple machines isn't a deal breaker.

File watching is debounced to prevent excessive regeneration when making frequent changes, as well as to address the fact that file changes are a bit "noisy" - a single change can yield multiple events from the FileWatcher dependency. 

The current implementation is very opinionated - only the default Sources, Resources and Content folders are watched for changes, and the debounce duration cannot be changed. All of these could be made configurable, but I think that could be done in a follow up PR, should this one be accepted. (And for folder watching in particular, it would be helpful if the CLI used [swift-argument-parser](https://github.com/apple/swift-argument-parser) to make it easier to add support for new arguments)

There is one edge case that I haven't been able to figure out - changes to files in the `Resources` folder trigger more than one regeneration - it seems that the regeneration itself ends up counting as a change which puts it into a loop that it eventually gets out of after a few cycles. The same file in the Sources or Content folder doesn't cause this problem. I have a solution for this (using Apple's CryptoKit to generate SHA256 hashes of the changed files, and compare those before scheduling another regeneration), but I'd like to know whether or not introducing an additional dependency would be a problem.