### PR TITLE
Improved Automatic Title Generation to Exclude Index

### DIFF
--- a/Sources/Publish/API/PlotComponents.swift
+++ b/Sources/Publish/API/PlotComponents.swift
@@ -34,7 +34,7 @@ public extension Node where Context == HTML.DocumentContext {
     ) -> Node {
         var title = location.title
 
-        if title.isEmpty {
+        if title.isEmpty || title.lowercased() == "index" {
             title = site.name
         } else {
             title.append(titleSeparator + site.name)


### PR DESCRIPTION
Currently if I for example have a project named "Homepage" using publish the title displayed in the tab bar for the start page would not be "Homepage" but "index | Homepage". This pull request specifically excludes files named index.