### PR TITLE
Add public async versions of `publish` method

### DIFF
--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -130,6 +130,67 @@ public extension Website {
         semaphore.wait()
         return try result!.get()
     }
+    
+    /// Publish this website using a default pipeline. To build a completely
+    /// custom pipeline, use the `publish(using:)` method.
+    /// - parameter theme: The HTML theme to generate the website using.
+    /// - parameter indentation: How to indent the generated files.
+    /// - parameter path: Any specific path to generate the website at.
+    /// - parameter rssFeedSections: What sections to include in the site's RSS feed.
+    /// - parameter rssFeedConfig: The configuration to use for the site's RSS feed.
+    /// - parameter deploymentMethod: How to deploy the website.
+    /// - parameter additionalSteps: Any additional steps to add to the publishing
+    ///   pipeline. Will be executed right before the HTML generation process begins.
+    /// - parameter plugins: Plugins to be installed at the start of the publishing process.
+    /// - parameter file: The file that this method is called from (auto-inserted).
+    /// - parameter line: The line that this method is called from (auto-inserted).
+    @discardableResult
+    func publish(withTheme theme: Theme<Self>,
+                 indentation: Indentation.Kind? = nil,
+                 at path: Path? = nil,
+                 rssFeedSections: Set<SectionID> = Set(SectionID.allCases),
+                 rssFeedConfig: RSSFeedConfiguration? = .default,
+                 deployedUsing deploymentMethod: DeploymentMethod<Self>? = nil,
+                 additionalSteps: [PublishingStep<Self>] = [],
+                 plugins: [Plugin<Self>] = [],
+                 file: StaticString = #file) async throws -> PublishedWebsite<Self> {
+        try await publish(
+            at: path,
+            using: [
+                .group(plugins.map(PublishingStep.installPlugin)),
+                .optional(.copyResources()),
+                .addMarkdownFiles(),
+                .sortItems(by: \.date, order: .descending),
+                .group(additionalSteps),
+                .generateHTML(withTheme: theme, indentation: indentation),
+                .unwrap(rssFeedConfig) { config in
+                    .generateRSSFeed(
+                        including: rssFeedSections,
+                        config: config
+                    )
+                },
+                .generateSiteMap(indentedBy: indentation),
+                .unwrap(deploymentMethod, PublishingStep.deploy)
+            ],
+            file: file
+        )
+    }
+    
+    /// Publish this website using a custom pipeline.
+    /// - parameter path: Any specific path to generate the website at.
+    /// - parameter steps: The steps to use to form the website's publishing pipeline.
+    /// - parameter file: The file that this method is called from (auto-inserted).
+    /// - parameter line: The line that this method is called from (auto-inserted).
+    @discardableResult
+    func publish(at path: Path? = nil,
+                 using steps: [PublishingStep<Self>],
+                 file: StaticString = #file) async throws -> PublishedWebsite<Self> {
+        let pipeline = PublishingPipeline(
+            steps: steps,
+            originFilePath: Path("\(file)")
+        )
+        return try await pipeline.execute(for: self, at: path)
+    }
 }
 
 // MARK: - Paths and URLs


### PR DESCRIPTION
## Motivation
- Allow Publish to run on [platforms](https://swiftwasm.org) which cannot support a `DispatchSemaphore`.
- Allow calling Publish from async contexts without the risk of deadlock.
- Keeping existing clients intact.

## Changes
Adding alternative `async` versions of the `Website.publish` methods.

Compared with the approach of [replacing sync with async versions](https://github.com/JohnSundell/Publish/pull/141), this PR keeps all tests passing and *almost* doesn't break calling sites.

This is technically a breaking change but in a pretty minimal way, according to calling context:
- In a `synchronous` function, the sync version will be inferred as before - no change.
- In `main.swift` top-level code, the sync version will be inferred as before (adding `await` in the call will result in a warning).
- In an `async` function - the code will break with a helpful compiler error:
```
Expression is 'async' but is not marked with 'await' 
Fix: Insert 'await '
```