### PR TITLE
Changed website.url() to return path as is if it contains an absolute…

### DIFF
--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -224,6 +224,8 @@ public extension Website {
     /// - parameter path: The path to return a URL for.
     func url(for path: Path) -> URL {
         guard !path.string.isEmpty else { return url }
+        guard !path.string.hasPrefix("http://") else { return URL(string: path.string) ?? url }
+        guard !path.string.hasPrefix("https://") else { return URL(string: path.string) ?? url }
         return url.appendingPathComponent(path.string)
     }
 

--- a/Tests/PublishTests/Tests/WebsiteTests.swift
+++ b/Tests/PublishTests/Tests/WebsiteTests.swift
@@ -72,6 +72,13 @@ final class WebsiteTests: PublishTestCase {
             URL(string: "https://swiftbysundell.com/a/path")
         )
     }
+    
+    func testURLForPathContainingAbsoluteURL() {
+        XCTAssertEqual(
+            website.url(for: Path("https://swiftbysundell.com/a/path")),
+            URL(string: "https://swiftbysundell.com/a/path")
+        )
+    }
 
     func testURLForLocation() {
         let page = Page(path: "mypage", content: Content())


### PR DESCRIPTION
I have absolute urls for my episode images hosted on digital ocean spaces.  As it is, website.url() assumes path is a system path (absolute or relative), instead of containing an absolute url.  This results in invalid urls when it prepends path with website.url.
I changed it to check for `http://` and `https://`.